### PR TITLE
feat(action-bar): 支持自定义dom元素

### DIFF
--- a/src/chat-action/action.tsx
+++ b/src/chat-action/action.tsx
@@ -145,21 +145,42 @@ export const renderActions = (
 
   const arrayActions: TdChatActionItem[] =
     Array.isArray(actionBar) && actionBar.length > 0
-      ? actionBar.map((action) => presetActions().find((item) => item.name === action))
+      ? actionBar.map((action) => {
+          // 兼容preset的旧逻辑
+          if (typeof action === 'string') {
+            return presetActions().find((item) => item.name === action);
+          }
+          return action;
+        })
       : presetActions();
 
   return (
     <div className={className}>
-      {arrayActions.map((item, index) =>
-        item.name === 'replay' && index + 1 !== arrayActions.length ? (
-          <div class={`${className}__refresh`}>
-            {item.render}
-            <span class={`${className}__refresh-line`} />
-          </div>
-        ) : (
-          item.render
-        ),
-      )}
+      {arrayActions.map((item, index) => {
+        if (!item) return null;
+        if (item.name === 'replay' && index + 1 !== arrayActions.length) {
+          return (
+            <div class={`${className}__refresh`}>
+              {item.render}
+              <span class={`${className}__refresh-line`} />
+            </div>
+          );
+        }
+        // preset action
+        if (item.render) return item.render;
+        // custom action
+        if (item.name) {
+          if (item.ignoreWrapper) {
+            return <slot name={item.name} />;
+          }
+          return (
+            <span class={`${className}__item__wrapper`}>
+              <slot name={item.name} />
+            </span>
+          );
+        }
+        return null;
+      })}
     </div>
   );
 };

--- a/src/chat-action/type.ts
+++ b/src/chat-action/type.ts
@@ -7,6 +7,7 @@ export type TdChatActionsName = 'copy' | 'good' | 'bad' | 'replay' | 'share';
 export type TdChatActionItem = {
   name: TdChatActionsName;
   render: TNode;
+  ignoreWrapper?: boolean;
 };
 
 interface ChatActionProps {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue


### 💡 需求背景和解决方案

<img width="568" height="517" alt="企业微信截图_1538bbfa-856e-474c-8767-78ab2079f613" src="https://github.com/user-attachments/assets/69e78e97-6a0e-4985-a55b-5bdbd0074f2b" />

- [ ] 本条 PR 不需要纳入 Changelog

### 📝 更新日志

- feat(action-bar): 支持自定义dom元素

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
