### PR TITLE
feat(chat-sender): 新增 `sendBtnDisabled` 支持禁止发送按钮

### DIFF
--- a/src/chat-sender/README.md
+++ b/src/chat-sender/README.md
@@ -10,6 +10,10 @@ spline: base
 
 {{ basic }}
 
+### 禁用发送按钮
+
+{{ sendBtnDisabled }}
+
 ### 附件发送
 
 {{ attachment }}
@@ -32,6 +36,7 @@ spline: base
 | `defaultValue` | `string` | - | 输入框默认值（非受控模式） |
 | `loading` | `boolean` | `false` | 是否加载中 |
 | `autosize` | `boolean \| { minRows?: number; maxRows?: number }` | `{ minRows: 2 }` | 高度自动撑开 |
+| `sendBtnDisabled` | `boolean \| ((inputValue: string) => boolean)` | - | 禁用发送按钮，支持布尔值或函数形式。默认输入为空时禁用 |
 
 ## 操作按钮配置
 

--- a/src/chat-sender/_example/basic.tsx
+++ b/src/chat-sender/_example/basic.tsx
@@ -7,12 +7,6 @@ export default class BasicExample extends Component {
 
   loading = signal<boolean>(false);
 
-  handleReadyToSend = (v: string): boolean => {
-    console.log('handleReadyToSend', v);
-    // 无论内容是否为空，始终允许发送
-    return true;
-  };
-
   onChange = (e: CustomEvent) => {
     console.log('onChange', e);
     this.inputValue.value = e.detail;
@@ -44,7 +38,6 @@ export default class BasicExample extends Component {
         placeholder="请输入内容"
         loading={this.loading.value}
         autosize={{ minRows: 2 }}
-        readyToSend={this.handleReadyToSend}
         onChange={this.onChange}
         onSend={this.onSend}
         onStop={this.onStop}

--- a/src/chat-sender/_example/sendBtnDisabled.tsx
+++ b/src/chat-sender/_example/sendBtnDisabled.tsx
@@ -1,5 +1,6 @@
 import 'tdesign-web-components/chatbot';
 import 'tdesign-web-components/switch';
+import 'tdesign-web-components/tabs';
 
 import { bind, Component, signal } from 'omi';
 
@@ -16,23 +17,52 @@ export default class SendBtnDisabledExample extends Component {
 
   render() {
     return (
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-          <t-switch value={this.disabled.value} onChange={this.onSwitchChange} />
-          <span>禁用发送按钮</span>
-        </div>
-        <t-chat-sender
-          value={this.inputValue.value}
-          placeholder="请输入内容"
-          sendBtnDisabled={this.disabled.value}
-          onChange={(e: CustomEvent) => {
-            this.inputValue.value = e.detail;
-          }}
-          onSend={() => {
-            this.inputValue.value = '';
-          }}
-        />
-      </div>
+      <t-tabs defaultValue={1}>
+        <t-tab-panel value={1} label="布尔值控制">
+          <div style={{ padding: '16px 0', display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              <t-switch value={this.disabled.value} onChange={this.onSwitchChange} />
+              <span>禁用发送按钮</span>
+            </div>
+            <t-chat-sender
+              value={this.inputValue.value}
+              placeholder="请输入内容"
+              sendBtnDisabled={this.disabled.value}
+              onChange={(e: CustomEvent) => {
+                this.inputValue.value = e.detail;
+              }}
+              onSend={() => {
+                this.inputValue.value = '';
+              }}
+            />
+          </div>
+        </t-tab-panel>
+
+        <t-tab-panel value={2} label="函数控制-长度判断">
+          <div style={{ padding: '16px 0' }}>
+            <t-chat-sender
+              placeholder="请输入至少5个字符"
+              sendBtnDisabled={(value: string) => !value || value.length < 5}
+              onSend={(e: CustomEvent) => {
+                console.log('发送内容：', e.detail.value);
+              }}
+            />
+          </div>
+        </t-tab-panel>
+
+        <t-tab-panel value={3} label="函数控制-格式验证">
+          <div style={{ padding: '16px 0' }}>
+            <div>必须包含@</div>
+            <t-chat-sender
+              placeholder="请输入邮箱地址"
+              sendBtnDisabled={(value: string) => !value || !value.includes('@')}
+              onSend={(e: CustomEvent) => {
+                console.log('发送邮箱：', e.detail.value);
+              }}
+            />
+          </div>
+        </t-tab-panel>
+      </t-tabs>
     );
   }
 }

--- a/src/chat-sender/_example/sendBtnDisabled.tsx
+++ b/src/chat-sender/_example/sendBtnDisabled.tsx
@@ -1,0 +1,38 @@
+import 'tdesign-web-components/chatbot';
+import 'tdesign-web-components/switch';
+
+import { bind, Component, signal } from 'omi';
+
+export default class SendBtnDisabledExample extends Component {
+  inputValue = signal('输入内容');
+
+  disabled = signal<boolean>(false);
+
+  @bind
+  onSwitchChange(value: boolean) {
+    this.disabled.value = value;
+    this.update();
+  }
+
+  render() {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <t-switch value={this.disabled.value} onChange={this.onSwitchChange} />
+          <span>禁用发送按钮</span>
+        </div>
+        <t-chat-sender
+          value={this.inputValue.value}
+          placeholder="请输入内容"
+          sendBtnDisabled={this.disabled.value}
+          onChange={(e: CustomEvent) => {
+            this.inputValue.value = e.detail;
+          }}
+          onSend={() => {
+            this.inputValue.value = '';
+          }}
+        />
+      </div>
+    );
+  }
+}

--- a/src/chat-sender/chat-sender.tsx
+++ b/src/chat-sender/chat-sender.tsx
@@ -106,7 +106,7 @@ export default class ChatSender extends Component<TdChatSenderProps> {
     }
     if (props.attachmentsProps.items !== oldProps.attachmentsProps.items) return true;
     if (props.loading !== oldProps.loading) return true;
-    if (typeof props.sendBtnDisabled === 'boolean' && props.sendBtnDisabled !== oldProps.sendBtnDisabled) return true;
+    if (props.sendBtnDisabled !== oldProps.sendBtnDisabled) return true;
     return false;
   }
 

--- a/src/chat-sender/chat-sender.tsx
+++ b/src/chat-sender/chat-sender.tsx
@@ -36,7 +36,7 @@ export default class ChatSender extends Component<TdChatSenderProps> {
     attachmentsProps: Object,
     textareaProps: Object,
     uploadProps: Object,
-    readyToSend: Function,
+    sendBtnDisabled: [Boolean, Function],
     onFileSelect: Function,
     onFileRemove: Function,
     onSend: Function,
@@ -106,6 +106,7 @@ export default class ChatSender extends Component<TdChatSenderProps> {
     }
     if (props.attachmentsProps.items !== oldProps.attachmentsProps.items) return true;
     if (props.loading !== oldProps.loading) return true;
+    if (typeof props.sendBtnDisabled === 'boolean' && props.sendBtnDisabled !== oldProps.sendBtnDisabled) return true;
     return false;
   }
 
@@ -160,7 +161,7 @@ export default class ChatSender extends Component<TdChatSenderProps> {
         className={classname([
           `${className}__button`,
           {
-            [`${className}__button--focus`]: this.isReadyToSend || this.props.loading,
+            [`${className}__button--focus`]: !this.isSendBtnDisabled || this.props.loading,
           },
         ])}
         onClick={this.clickSend}
@@ -190,10 +191,12 @@ export default class ChatSender extends Component<TdChatSenderProps> {
     ];
   }
 
-  get isReadyToSend() {
-    return this.props.readyToSend && typeof this.props.readyToSend === 'function'
-      ? this.props.readyToSend(this.inputValue)
-      : this.inputValue && this.inputValue.trim() !== '';
+  get isSendBtnDisabled() {
+    const { sendBtnDisabled } = this.props;
+    if (typeof sendBtnDisabled === 'boolean') return sendBtnDisabled;
+    if (typeof sendBtnDisabled === 'function') return sendBtnDisabled(this.inputValue);
+    // 默认：输入为空时禁用
+    return !this.inputValue || this.inputValue.trim() === '';
   }
 
   private renderActions = () => {
@@ -322,7 +325,7 @@ export default class ChatSender extends Component<TdChatSenderProps> {
   };
 
   private handleSend = () => {
-    if (this.props.disabled || !this.isReadyToSend) {
+    if (this.props.disabled || this.isSendBtnDisabled) {
       return;
     }
     this.fire(

--- a/src/chat-sender/type.ts
+++ b/src/chat-sender/type.ts
@@ -31,10 +31,10 @@ export interface TdChatSenderProps extends Pick<TdTextareaProps, 'autosize'> {
   /** 透传input-file参数 */
   uploadProps?: Omit<JSX.HTMLAttributes, 'onChange' | 'ref' | 'type' | 'hidden'>;
   /**
-   * 覆盖发送条件，返回为true时标识为可发送
-   * @default value不为空时可发送
+   * 禁用发送按钮，支持布尔值或函数形式
+   * @default false
    */
-  readyToSend?: (inputValue: string) => boolean;
+  sendBtnDisabled?: boolean | ((inputValue: string) => boolean);
   onSend?: (e: CustomEvent<TdChatSenderParams>) => ChatRequestParams | void;
   onStop?: (e: CustomEvent<string>) => void;
   onChange?: (e: CustomEvent<string>) => void;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

`readyToSend` 在次 pr 中被替换为 `sendBtnDisabled`

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(chat-sender): 新增 `sendBtnDisabled` 支持布尔值或函数形式

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
