### PR TITLE
fix(chatBot): senderProps onSend/onStop are properly invoked 

### DIFF
--- a/src/chatbot/chat.tsx
+++ b/src/chatbot/chat.tsx
@@ -296,6 +296,7 @@ export default class Chatbot extends Component<TdChatProps> implements TdChatbot
    * 处理发送消息事件
    */
   private handleSend = async (e: CustomEvent<TdChatSenderParams>) => {
+    this.props.senderProps?.onSend?.(e);
     const { value, attachments } = e.detail;
     const params = {
       prompt: value,
@@ -307,7 +308,8 @@ export default class Chatbot extends Component<TdChatProps> implements TdChatbot
   /**
    * 处理停止聊天事件
    */
-  private handleStop = () => {
+  private handleStop = (e?: CustomEvent<string>) => {
+    this.props.senderProps?.onStop?.(e);
     this.chatEngine.abortChat();
     this.fire(
       'chat_stop',


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[#6554](https://github.com/Tencent/tdesign-vue-next/issues/6554)
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
- #### 问题背景 
Chatbot 组件支持通过 senderProps 透传 ChatSender 的属性，但 senderProps.onSend 和 senderProps.onStop 实际不会触发。
- #### 解决方案
在 `chat.tsx` 的 `handleSend` 和 `handleStop` 里，补调 `this.props.senderProps?.onSend?.(e)` 和 `this.props.senderProps?.onStop?.(e)`。    
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(chatBot): 修复`chatBot` 无法回调 `SenderPorps` 里面 `onSend` 和 `onStop` 问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
