### PR TITLE
feat(file-card): support mini image preview 

### DIFF
--- a/src/filecard/filecard.tsx
+++ b/src/filecard/filecard.tsx
@@ -294,7 +294,6 @@ export default class FileCard extends Component<TdFileCardProps> {
             {icon}
           </div>
         )}
-
         <div className={`${className}-content`}>
           <div className={`${className}-name`}>
             <span className={`${className}-name-prefix`}>{namePrefix || this.EMPTY}</span>

--- a/src/filecard/filecard.tsx
+++ b/src/filecard/filecard.tsx
@@ -287,9 +287,14 @@ export default class FileCard extends Component<TdFileCardProps> {
     }
     return (
       <>
-        <div className={`${className}-icon ${className}-icon__${item.status}`} style={{ color: iconColor }}>
-          {icon}
-        </div>
+        {item.url ? (
+          <t-image className={`${className}-overview-image-mini`} src={item.url} shape="round" fit="cover" />
+        ) : (
+          <div className={`${className}-icon ${className}-icon__${item.status}`} style={{ color: iconColor }}>
+            {icon}
+          </div>
+        )}
+
         <div className={`${className}-content`}>
           <div className={`${className}-name`}>
             <span className={`${className}-name-prefix`}>{namePrefix || this.EMPTY}</span>

--- a/src/filecard/style/_var.less
+++ b/src/filecard/style/_var.less
@@ -27,6 +27,9 @@
 
 @file-card-icon-height: 32px;
 @file-card-icon-width: 32px;
+// 图片小图尺寸
+@file-card-image-mini-width:36px;
+@file-card-image-mini-height:36px;
 
 @file-card-icon-loading-color: var(--td-brand-color);
 @file-card-icon-default-color: #8c8c8c;

--- a/src/filecard/style/_var.less
+++ b/src/filecard/style/_var.less
@@ -27,9 +27,8 @@
 
 @file-card-icon-height: 32px;
 @file-card-icon-width: 32px;
-// 图片小图尺寸
-@file-card-image-mini-width:36px;
-@file-card-image-mini-height:36px;
+@file-card-image-mini-width: 36px;
+@file-card-image-mini-height: 36px;
 
 @file-card-icon-loading-color: var(--td-brand-color);
 @file-card-icon-default-color: #8c8c8c;

--- a/src/filecard/style/filecard.less
+++ b/src/filecard/style/filecard.less
@@ -24,7 +24,11 @@
       height: auto;
       padding: 0px;
     }
-    
+    &-image-mini{
+        width: @file-card-image-mini-width;
+        height: @file-card-image-mini-height;
+    }
+
     
   }
   

--- a/src/filecard/style/filecard.less
+++ b/src/filecard/style/filecard.less
@@ -24,12 +24,10 @@
       height: auto;
       padding: 0px;
     }
-    &-image-mini{
-        width: @file-card-image-mini-width;
-        height: @file-card-image-mini-height;
+    &-image-mini {
+      width: @file-card-image-mini-width;
+      height: @file-card-image-mini-height;
     }
-
-    
   }
   
   &-name {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/pull/6563#issuecomment-4174501706
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
现在的 `file-card` 组件对于多文件类型的情况图片是无法根据url显示出图片的缩略图。
#### 修改前
<img width="1224" height="533" alt="image" src="https://github.com/user-attachments/assets/a949569e-2ebd-40a8-a321-5e56a93dc644" />

#### 修复后
<img width="1250" height="460" alt="image" src="https://github.com/user-attachments/assets/79781db7-740f-4c09-8459-a3b45a1496c5" />

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(file-card): 支持文件卡片的小图预览

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
