### PR TITLE
[next] fix(chat): 隔离外部附件与消息状态

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:chat": "pnpm run build:ui && pnpm --filter @tdesign/web-components-chat build",
     "lint": "pnpm run check:types && eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "echo \"暂无单元测试，跳过\"",
+    "test": "node --import tsx --test packages/pro-components/chat/chatbot/__tests__/*.test.ts",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/packages/pro-components/chat/chatbot/__tests__/attachment.test.ts
+++ b/packages/pro-components/chat/chatbot/__tests__/attachment.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { TdAttachmentItem } from '../../filecard';
+import { createChatMessageAttachments } from '../attachment';
+
+test('creates owned message DTOs without reading upload-only objects', () => {
+  const source = {
+    name: 'report.pdf',
+    size: 1024,
+    status: 'success',
+    type: 'application/pdf',
+    url: 'https://example.com/report.pdf',
+    description: '1KB',
+  } as TdAttachmentItem;
+
+  Object.defineProperties(source, {
+    raw: {
+      enumerable: true,
+      get: () => {
+        throw new Error('raw must stay outside the message store');
+      },
+    },
+    response: {
+      enumerable: true,
+      get: () => {
+        throw new Error('response must stay outside the message store');
+      },
+    },
+  });
+
+  const [messageAttachment] = createChatMessageAttachments([source]);
+
+  assert.notEqual(messageAttachment, source);
+  assert.deepEqual(messageAttachment, {
+    key: undefined,
+    fileType: 'pdf',
+    name: 'report.pdf',
+    size: 1024,
+    url: 'https://example.com/report.pdf',
+    extension: 'pdf',
+    status: 'success',
+    type: 'application/pdf',
+    description: '1KB',
+    percent: undefined,
+  });
+  assert.equal('raw' in messageAttachment, false);
+  assert.equal('response' in messageAttachment, false);
+});
+
+test('creates a new snapshot on every send and infers common attachment types', () => {
+  const source: TdAttachmentItem = {
+    name: 'recording.mp3',
+    size: 2048,
+  };
+
+  const first = createChatMessageAttachments([source]);
+  const second = createChatMessageAttachments([source]);
+
+  assert.notEqual(first, second);
+  assert.notEqual(first?.[0], second?.[0]);
+  assert.equal(first?.[0].fileType, 'audio');
+  assert.equal(first?.[0].extension, 'mp3');
+});

--- a/packages/pro-components/chat/chatbot/attachment.ts
+++ b/packages/pro-components/chat/chatbot/attachment.ts
@@ -1,0 +1,50 @@
+import type { AttachmentItem, AttachmentType } from '../chat-engine';
+import type { TdAttachmentItem } from '../filecard';
+
+export type TdChatMessageAttachment = AttachmentItem &
+  Pick<TdAttachmentItem, 'key' | 'status' | 'type' | 'description' | 'percent'>;
+
+const attachmentTypeByMime = (mimeType?: string): AttachmentType | undefined => {
+  const category = mimeType?.split('/')[0];
+  if (category === 'image' || category === 'video' || category === 'audio') return category;
+  if (mimeType === 'application/pdf') return 'pdf';
+  return undefined;
+};
+
+const attachmentTypeByExtension = (extension?: string): AttachmentType => {
+  const normalized = extension?.replace(/^\./, '').toLowerCase();
+  if (['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'svg'].includes(normalized)) return 'image';
+  if (['mp4', 'avi', 'mov', 'wmv', 'flv', 'mkv'].includes(normalized)) return 'video';
+  if (['mp3', 'wav', 'flac', 'ape', 'aac', 'ogg'].includes(normalized)) return 'audio';
+  if (normalized === 'pdf') return 'pdf';
+  if (['doc', 'docx'].includes(normalized)) return 'doc';
+  if (['ppt', 'pptx'].includes(normalized)) return 'ppt';
+  return 'txt';
+};
+
+const getExtension = (attachment: TdAttachmentItem) =>
+  attachment.extension || attachment.name?.match(/\.([^.]+)$/)?.[1];
+
+/**
+ * 创建由 ChatEngine 自己持有的消息附件快照。
+ * 上传过程对象（raw、response 等）只属于发送方，不能进入 Immer 消息状态。
+ */
+export const createChatMessageAttachment = (attachment: TdAttachmentItem): TdChatMessageAttachment => {
+  const extension = getExtension(attachment);
+
+  return {
+    key: attachment.key,
+    fileType: attachment.fileType || attachmentTypeByMime(attachment.type) || attachmentTypeByExtension(extension),
+    name: attachment.name,
+    size: attachment.size,
+    url: attachment.url,
+    extension,
+    status: attachment.status,
+    type: attachment.type,
+    description: attachment.description,
+    percent: attachment.percent,
+  };
+};
+
+export const createChatMessageAttachments = (attachments?: TdAttachmentItem[]) =>
+  attachments?.map(createChatMessageAttachment);

--- a/packages/pro-components/chat/chatbot/chat.tsx
+++ b/packages/pro-components/chat/chatbot/chat.tsx
@@ -23,6 +23,7 @@ import type { TdChatMessageActionName, TdChatMessageProps } from '../chat-messag
 import { TdChatSenderParams } from '../chat-sender';
 import type ChatSender from '../chat-sender/chat-sender';
 import { TdAttachmentItem } from '../filecard';
+import { createChatMessageAttachments } from './attachment';
 import type Chatlist from './chat-list';
 import type { TdChatbotApi, TdChatListScrollToOptions, TdChatMessageConfig, TdChatProps } from './type';
 
@@ -299,7 +300,7 @@ export default class Chatbot extends Component<TdChatProps> implements TdChatbot
     const { value, attachments } = e.detail;
     const params = {
       prompt: value,
-      attachments,
+      attachments: createChatMessageAttachments(attachments),
     } as ChatRequestParams;
     await this.sendUserMessage(params);
   };

--- a/packages/tdesign-web-components-chat/package.json
+++ b/packages/tdesign-web-components-chat/package.json
@@ -50,6 +50,7 @@
   ],
   "sideEffects": [
     "dist/**",
+    "esm/**/*.js",
     "**/style/**",
     "**/*.css"
   ],

--- a/packages/tdesign-web-components/package.json
+++ b/packages/tdesign-web-components/package.json
@@ -49,6 +49,7 @@
   ],
   "sideEffects": [
     "dist/**",
+    "esm/**/*.js",
     "**/style/**",
     "**/*.css"
   ],

--- a/packages/vite-config/src/lib/config.ts
+++ b/packages/vite-config/src/lib/config.ts
@@ -57,6 +57,19 @@ function createSharedPlugins(monorepoRoot: string, generateEntry: boolean) {
   ];
 }
 
+/**
+ * ESM 构建使用多入口而不是 Vite 的 build.lib，Vite 因此默认允许摇掉入口导出。
+ * 发布包的每个组件 index 都是公开入口，必须完整保留其导出签名。
+ */
+function preservePublicEntryExportsPlugin(): Plugin {
+  return {
+    name: 'preserve-public-entry-exports',
+    options(inputOptions) {
+      return { ...inputOptions, preserveEntrySignatures: 'strict' };
+    },
+  };
+}
+
 function createSharedUserConfig(
   options: LibViteOptions,
   monorepoRoot: string,
@@ -104,7 +117,11 @@ function createEsmConfig(options: LibViteOptions): UserConfig {
         },
       },
     },
-    plugins: [...createSharedPlugins(monorepoRoot, options.generateEntry ?? false), createLibDtsPlugin(options.srcDir)],
+    plugins: [
+      preservePublicEntryExportsPlugin(),
+      ...createSharedPlugins(monorepoRoot, options.generateEntry ?? false),
+      createLibDtsPlugin(options.srcDir),
+    ],
   };
 }
 

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -42,6 +42,12 @@ function checkReleaseVersions() {
     chatPackage.peerDependencies?.['@tdesign/web-components'] === `^${uiPackage.version}`,
     'Chat peer dependency must match the current UI package version',
   );
+  for (const [name, pkg] of [
+    ['UI', uiPackage],
+    ['Chat', chatPackage],
+  ]) {
+    assert(pkg.sideEffects?.includes('esm/**/*.js'), `${name} package must preserve ESM registration side effects`);
+  }
   console.log(`[check:pack] release versions aligned (${uiPackage.version})`);
 }
 
@@ -154,6 +160,16 @@ function checkComponentEntries({ name, sourceDir, packageDir }) {
   console.log(`[check:pack] ${name} ESM component entries ok`);
 }
 
+function checkRuntimeExports() {
+  const messageEntry = readFileSync(resolve(repoRoot, 'packages/tdesign-web-components/esm/message/index.js'), 'utf8');
+
+  assert(
+    /export\s*\{[^}]*\bMessagePlugin\b[^}]*\}/s.test(messageEntry),
+    '[ui] message ESM entry is missing the runtime MessagePlugin export',
+  );
+  console.log('[check:pack] UI runtime exports ok');
+}
+
 checkReleaseVersions();
 
 for (const pkg of packages) {
@@ -162,3 +178,5 @@ for (const pkg of packages) {
   checkResolvable(pkg);
   checkComponentEntries(pkg);
 }
+
+checkRuntimeExports();


### PR DESCRIPTION
> [!IMPORTANT]
> 本 PR 仅保留为 `next` 分包线的后续方案，不用于当前 `develop` 单包发布线。当前发布线的最小修复见 [#411](https://github.com/TDesignOteam/tdesign-web-components/pull/411)。

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] CI/CD 改进
- [x] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- https://github.com/TDesignOteam/tdesign-web-components/issues/381
- 旧版最小复现：https://stackblitz.com/edit/hxxsvh94-4slpjzak?file=README.md
- 修复后验证：https://stackblitz.com/github/RSS1102/omi-vueify-proxy-ab/tree/rss1102/chat-pr-6879?file=src%2FApp.vue&startScript=stackblitz

### 💡 需求背景和解决方案

Vue 使用普通 `ref([])` 保存附件时，传入 Web Component 的 `TdAttachmentItem` 可以是 Vue Proxy。问题不在于 Web Component 接收了 Proxy，而在于旧实现把调用方的完整附件原引用写入 ChatEngine/Immer 消息状态并冻结，随后深层遍历可能触发 Proxy invariant / `Subscriber error`。

本 PR 不检测 Vue Proxy，也不增加递归解包兼容层，而是修正数据所有权：

1. `t-chat-sender` 的附件继续作为外部上传状态使用；
2. `t-chatbot` 发送时按 ChatEngine `AttachmentItem` 契约创建新的消息附件 DTO；
3. `raw`、`response` 等上传过程对象不进入 Immer 消息状态；
4. 消息 Store 只保存组件自己拥有、可以安全冻结的展示字段快照；
5. 每次发送都会创建独立快照，不持有或冻结调用方对象。

业务现有的 `markRaw(senderProps)` 用法仍然兼容，但不再是发送附件成功的必要条件；普通 `ref([])` 也可以直接使用。

### 📦 发布包边界

外部 Vite 消费验证还发现并修复了两个发布契约问题：

- ESM 使用多入口构建但未走 `build.lib`，Vite 默认 `preserveEntrySignatures: false`，会移除公开入口中未被包内使用的运行时导出；现在显式保留公开入口签名，并校验 `MessagePlugin` 的真实 JS 导出。
- Web Components 的注册依赖模块副作用；两个发布包现在声明 `esm/**/*.js` 为 `sideEffects`，避免消费者生产构建删除 `customElements` 注册代码。

预览包（同一提交 `ad8570a`）：

```text
https://pkg.pr.new/TDesignOteam/tdesign-web-components/@tdesign/web-components@ad8570a
https://pkg.pr.new/TDesignOteam/tdesign-web-components/@tdesign/web-components-chat@ad8570a
```

### ✅ 验证结果

- 附件所有权单测：2/2 通过；覆盖不读取 `raw` / `response`、每次发送创建独立 DTO。
- `pnpm run check:types`：通过。
- `pnpm run check:pack`：通过；覆盖 UI/Chat 构建、包文件、声明引用、ESM 入口、运行时导出和注册副作用声明。
- 外部 Vue 3.5.41 + Vite 生产构建：通过。
- 真实浏览器：`t-chatbot` 已注册并拥有 Shadow DOM；输入附件为 Proxy，消息附件为非 Proxy；发送成功，消息数为 3，运行错误为 0。

### 📝 更新日志

- fix(Chat): 发送附件进入消息状态前创建独立 DTO，避免持有和冻结外部上传对象

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
