### PR TITLE
fix(chat): 隔离外部附件与消息状态

### DIFF
--- a/src/chat-engine/__tests__/message-attachment.test.ts
+++ b/src/chat-engine/__tests__/message-attachment.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createMessageAttachments } from '../message-attachment.ts';
+import type { AttachmentItem } from '../type.ts';
+
+test('creates message-owned attachments without reading upload-only fields', () => {
+  const source = {
+    fileType: 'txt',
+    name: 'report.txt',
+    customField: 'preserved',
+  } as AttachmentItem & { customField: string };
+
+  Object.defineProperties(source, {
+    raw: {
+      enumerable: true,
+      get: () => {
+        throw new Error('raw must not be read');
+      },
+    },
+    response: {
+      enumerable: true,
+      get: () => {
+        throw new Error('response must not be read');
+      },
+    },
+  });
+
+  const input = [source];
+  const output = createMessageAttachments(input);
+  const messageAttachment = output?.[0] as AttachmentItem & { customField: string };
+
+  assert.notEqual(output, input);
+  assert.notEqual(messageAttachment, source);
+  assert.equal(messageAttachment.name, 'report.txt');
+  assert.equal(messageAttachment.customField, 'preserved');
+  assert.equal('raw' in messageAttachment, false);
+  assert.equal('response' in messageAttachment, false);
+
+  Object.freeze(messageAttachment);
+  source.name = 'updated.txt';
+  assert.equal(source.name, 'updated.txt');
+  assert.equal(Object.isFrozen(source), false);
+});
+
+test('preserves undefined and empty attachment inputs', () => {
+  assert.equal(createMessageAttachments(undefined), undefined);
+  assert.deepEqual(createMessageAttachments([]), []);
+});

--- a/src/chat-engine/index.ts
+++ b/src/chat-engine/index.ts
@@ -4,6 +4,7 @@ import { AGUIAdapter } from './adapters/agui';
 import { MessageStore } from './store/message';
 import type { ChatEventBusOptions, IChatEventBus } from './event-bus';
 import { ChatEngineEventType, ChatEventBus } from './event-bus';
+import { createMessageAttachments } from './message-attachment';
 import MessageProcessor from './processor';
 import { LLMService } from './server';
 import type {
@@ -132,7 +133,7 @@ export default class ChatEngine implements IChatEngine {
       return;
     }
 
-    const userMessage = this.messageProcessor.createUserMessage(prompt, attachments);
+    const userMessage = this.messageProcessor.createUserMessage(prompt, createMessageAttachments(attachments));
     const aiMessage = this.messageProcessor.createAssistantMessage();
     this.messageStore.createMultiMessages([userMessage, aiMessage]);
 

--- a/src/chat-engine/message-attachment.ts
+++ b/src/chat-engine/message-attachment.ts
@@ -1,0 +1,25 @@
+import type { AttachmentItem } from './type';
+
+type RequestAttachment = AttachmentItem & {
+  raw?: unknown;
+  response?: unknown;
+  [key: PropertyKey]: unknown;
+};
+
+const uploadOnlyKeys = new Set<PropertyKey>(['raw', 'response']);
+
+const createMessageAttachment = (attachment: RequestAttachment): AttachmentItem => {
+  const snapshot = {};
+
+  Reflect.ownKeys(attachment).forEach((key) => {
+    if (uploadOnlyKeys.has(key)) return;
+    const descriptor = Object.getOwnPropertyDescriptor(attachment, key);
+    if (!descriptor || !('value' in descriptor)) return;
+    Object.defineProperty(snapshot, key, descriptor);
+  });
+
+  return snapshot as AttachmentItem;
+};
+
+export const createMessageAttachments = (attachments?: AttachmentItem[]) =>
+  attachments?.map((attachment) => createMessageAttachment(attachment as RequestAttachment));


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无。

### 💡 需求背景和解决方案

#### 1. 原问题与修复动机

附件同时参与请求链路和消息状态链路。请求链路需要保留调用方传入的完整附件，包括上传文件、上传响应和用户自定义数据；消息状态链路则用于保存已经发送的消息。

旧实现把调用方拥有的附件数组和附件对象直接写入 ChatEngine/Immer 消息状态。调用方对象如果来自响应式框架，可能是 Proxy；当 Immer 冻结消息状态时，外部对象和内部状态仍然共享同一引用，后续读取可能触发 Proxy invariant，并表现为附件发送失败或 `Subscriber error`。

因此问题不在于 Web Component 接收了 Proxy，而在于外部附件没有在进入内部可冻结状态前完成数据所有权转换。

#### 2. 修复方案及选择原因

本次在创建用户消息的边界生成消息自有的附件快照：

1. 请求链路继续使用调用方传入的原附件；
2. 附件进入消息状态前，创建新的顶层数组和附件对象；
3. 复制附件自身的数据属性，保留消息字段和用户自定义数据属性；
4. 不读取 accessor，避免创建消息时触发外部 getter；
5. `raw`、`response` 属于上传过程对象，不写入消息状态；
6. 保持 `undefined` 和空数组的既有行为。

选择在消息创建边界处理，是因为这里才是附件从“调用方数据”转变为“组件内部消息状态”的位置。该方案不需要识别特定框架的 Proxy，也不需要调用 `toRaw` 等框架专用 API；同时只建立顶层快照，不递归遍历或克隆附件内容，避免扩大修复范围和改变附件数据结构。

#### 3. 用户使用和体验变化

- 已发送消息持有独立的顶层附件快照，调用方后续修改顶层附件字段不会反向修改已发送消息；
- ChatEngine 消息状态中的附件不再包含 `raw`、`response` 和 accessor 属性；这些上传过程数据仍保留在请求链路中；
- 自定义数据属性会进入消息快照，但复杂属性值不会被递归克隆，仍与调用方共享引用。

### 📝 更新日志

- fix(Chat): 创建用户消息时隔离外部附件与内部消息状态

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
