### PR TITLE
fix(chatbot): re-render on light DOM slot changes to fix delayed actionbar

### DIFF
--- a/src/chatbot/chat.tsx
+++ b/src/chatbot/chat.tsx
@@ -109,6 +109,8 @@ export default class Chatbot extends Component<TdChatProps> implements TdChatbot
     return false;
   }
 
+  private slotObserver?: MutationObserver;
+
   install() {
     this.chatEngine = new ChatEngine();
   }
@@ -116,6 +118,13 @@ export default class Chatbot extends Component<TdChatProps> implements TdChatbot
   ready(): void {
     this.initChat();
     this.update();
+    // Vue/React 桥接层会随消息状态动态增删 light DOM 插槽内容（如消息完成后插入的 actionbar）。
+    // Omi 不感知 light DOM 变化，新插槽要等下一次 render 才显示，这里监听 childList 变化主动触发更新。
+    // beforeRender 中已做 children 的差异刷新，此处仅负责触发渲染。
+    this.slotObserver = new MutationObserver(() => {
+      this.update();
+    });
+    this.slotObserver.observe(this, { childList: true });
   }
 
   /**
@@ -170,6 +179,7 @@ export default class Chatbot extends Component<TdChatProps> implements TdChatbot
   }
 
   uninstall() {
+    this.slotObserver?.disconnect();
     this.unsubscribeMsg?.();
     this.handleStop();
   }


### PR DESCRIPTION
## Description

Fixes Tencent/tdesign-vue-next#6841: the actionbar (and other dynamically inserted slots) in `t-chatbot` only appeared after sending a second message.

## Root Cause

- Vue/React bridges inject light DOM slot content dynamically as message state changes (e.g. the actionbar slot is inserted when the assistant message completes).
- Omi caches `props.children` at install time and has no built-in light DOM mutation handling, so the newly inserted slot content is only picked up on the **next** unrelated `update()`.
- `beforeRender` already refreshes children with a diff check (`childNodesChanged`), so the only missing piece was a render trigger.

## Changes

- `ready()`: observe `childList` mutations on the host element with a `MutationObserver` and call `update()`.
- `uninstall()`: disconnect the observer to avoid leaks.

## Verification

Browser A/B test on the docs site (localhost:15001):

| Scenario | Insert dynamic slot → rendered? |
|---|---|
| Before fix (control) | ❌ not rendered (shadow slot absent) |
| After fix | ✅ rendered within one tick |

## Notes

- Fix lives in the web-components (Omi) implementation, which is the rendering layer used by both the Vue and React bridges.