### PR TITLE
fix(chat): forward-port isolated attachment state to next

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:chat": "pnpm run build:ui && pnpm --filter @tdesign/web-components-chat build",
     "lint": "pnpm run check:types && eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "echo \"暂无单元测试，跳过\"",
+    "test": "node --import tsx --test packages/pro-components/chat/chatbot/__tests__/*.test.ts",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build:chat": "pnpm run build:ui && pnpm --filter @tdesign/web-components-chat build",
     "lint": "pnpm run check:types && eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "node --import tsx --test packages/pro-components/chat/chatbot/__tests__/*.test.ts",
+    "test": "pnpm run test:unit",
+    "test:unit": "node --import tsx --test 'packages/**/__tests__/*.{test,spec}.{ts,tsx,js,mjs,cjs}'",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "build:chat": "pnpm run build:ui && pnpm --filter @tdesign/web-components-chat build",
     "lint": "pnpm run check:types && eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "pnpm run test:unit",
-    "test:unit": "node --import tsx --test 'packages/**/__tests__/*.{test,spec}.{ts,tsx,js,mjs,cjs}'",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepare": "husky"
   },
   "lint-staged": {
@@ -65,7 +65,8 @@
     "tsx": "^4.21.0",
     "typescript": "catalog:tooling",
     "typescript-eslint": "catalog:tooling",
-    "vite": "catalog:tooling"
+    "vite": "catalog:tooling",
+    "vitest": "catalog:tooling"
   },
   "engines": {
     "node": ">=22.13.0"

--- a/packages/pro-components/chat/chatbot/__tests__/attachment.test.ts
+++ b/packages/pro-components/chat/chatbot/__tests__/attachment.test.ts
@@ -1,5 +1,4 @@
-import assert from 'node:assert/strict';
-import test from 'node:test';
+import { expect, test } from 'vitest';
 
 import type { TdAttachmentItem } from '../../filecard';
 import { createChatMessageAttachments } from '../attachment';
@@ -31,8 +30,8 @@ test('creates owned message DTOs without reading upload-only objects', () => {
 
   const [messageAttachment] = createChatMessageAttachments([source]);
 
-  assert.notEqual(messageAttachment, source);
-  assert.deepEqual(messageAttachment, {
+  expect(Object.is(messageAttachment, source)).toBe(false);
+  expect(messageAttachment).toEqual({
     key: undefined,
     fileType: 'pdf',
     name: 'report.pdf',
@@ -44,8 +43,8 @@ test('creates owned message DTOs without reading upload-only objects', () => {
     description: '1KB',
     percent: undefined,
   });
-  assert.equal('raw' in messageAttachment, false);
-  assert.equal('response' in messageAttachment, false);
+  expect('raw' in messageAttachment).toBe(false);
+  expect('response' in messageAttachment).toBe(false);
 });
 
 test('creates a new snapshot on every send and infers common attachment types', () => {
@@ -57,8 +56,8 @@ test('creates a new snapshot on every send and infers common attachment types', 
   const first = createChatMessageAttachments([source]);
   const second = createChatMessageAttachments([source]);
 
-  assert.notEqual(first, second);
-  assert.notEqual(first?.[0], second?.[0]);
-  assert.equal(first?.[0].fileType, 'audio');
-  assert.equal(first?.[0].extension, 'mp3');
+  expect(first).not.toBe(second);
+  expect(first?.[0]).not.toBe(second?.[0]);
+  expect(first?.[0].fileType).toBe('audio');
+  expect(first?.[0].extension).toBe('mp3');
 });

--- a/packages/pro-components/chat/chatbot/__tests__/attachment.test.ts
+++ b/packages/pro-components/chat/chatbot/__tests__/attachment.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { TdAttachmentItem } from '../../filecard';
+import { createChatMessageAttachments } from '../attachment';
+
+test('creates owned message DTOs without reading upload-only objects', () => {
+  const source = {
+    name: 'report.pdf',
+    size: 1024,
+    status: 'success',
+    type: 'application/pdf',
+    url: 'https://example.com/report.pdf',
+    description: '1KB',
+  } as TdAttachmentItem;
+
+  Object.defineProperties(source, {
+    raw: {
+      enumerable: true,
+      get: () => {
+        throw new Error('raw must stay outside the message store');
+      },
+    },
+    response: {
+      enumerable: true,
+      get: () => {
+        throw new Error('response must stay outside the message store');
+      },
+    },
+  });
+
+  const [messageAttachment] = createChatMessageAttachments([source]);
+
+  assert.notEqual(messageAttachment, source);
+  assert.deepEqual(messageAttachment, {
+    key: undefined,
+    fileType: 'pdf',
+    name: 'report.pdf',
+    size: 1024,
+    url: 'https://example.com/report.pdf',
+    extension: 'pdf',
+    status: 'success',
+    type: 'application/pdf',
+    description: '1KB',
+    percent: undefined,
+  });
+  assert.equal('raw' in messageAttachment, false);
+  assert.equal('response' in messageAttachment, false);
+});
+
+test('creates a new snapshot on every send and infers common attachment types', () => {
+  const source: TdAttachmentItem = {
+    name: 'recording.mp3',
+    size: 2048,
+  };
+
+  const first = createChatMessageAttachments([source]);
+  const second = createChatMessageAttachments([source]);
+
+  assert.notEqual(first, second);
+  assert.notEqual(first?.[0], second?.[0]);
+  assert.equal(first?.[0].fileType, 'audio');
+  assert.equal(first?.[0].extension, 'mp3');
+});

--- a/packages/pro-components/chat/chatbot/attachment.ts
+++ b/packages/pro-components/chat/chatbot/attachment.ts
@@ -1,0 +1,50 @@
+import type { AttachmentItem, AttachmentType } from '../chat-engine';
+import type { TdAttachmentItem } from '../filecard';
+
+export type TdChatMessageAttachment = AttachmentItem &
+  Pick<TdAttachmentItem, 'key' | 'status' | 'type' | 'description' | 'percent'>;
+
+const attachmentTypeByMime = (mimeType?: string): AttachmentType | undefined => {
+  const category = mimeType?.split('/')[0];
+  if (category === 'image' || category === 'video' || category === 'audio') return category;
+  if (mimeType === 'application/pdf') return 'pdf';
+  return undefined;
+};
+
+const attachmentTypeByExtension = (extension?: string): AttachmentType => {
+  const normalized = extension?.replace(/^\./, '').toLowerCase();
+  if (['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'svg'].includes(normalized)) return 'image';
+  if (['mp4', 'avi', 'mov', 'wmv', 'flv', 'mkv'].includes(normalized)) return 'video';
+  if (['mp3', 'wav', 'flac', 'ape', 'aac', 'ogg'].includes(normalized)) return 'audio';
+  if (normalized === 'pdf') return 'pdf';
+  if (['doc', 'docx'].includes(normalized)) return 'doc';
+  if (['ppt', 'pptx'].includes(normalized)) return 'ppt';
+  return 'txt';
+};
+
+const getExtension = (attachment: TdAttachmentItem) =>
+  attachment.extension || attachment.name?.match(/\.([^.]+)$/)?.[1];
+
+/**
+ * 创建由 ChatEngine 自己持有的消息附件快照。
+ * 上传过程对象（raw、response 等）只属于发送方，不能进入 Immer 消息状态。
+ */
+export const createChatMessageAttachment = (attachment: TdAttachmentItem): TdChatMessageAttachment => {
+  const extension = getExtension(attachment);
+
+  return {
+    key: attachment.key,
+    fileType: attachment.fileType || attachmentTypeByMime(attachment.type) || attachmentTypeByExtension(extension),
+    name: attachment.name,
+    size: attachment.size,
+    url: attachment.url,
+    extension,
+    status: attachment.status,
+    type: attachment.type,
+    description: attachment.description,
+    percent: attachment.percent,
+  };
+};
+
+export const createChatMessageAttachments = (attachments?: TdAttachmentItem[]) =>
+  attachments?.map(createChatMessageAttachment);

--- a/packages/pro-components/chat/chatbot/chat.tsx
+++ b/packages/pro-components/chat/chatbot/chat.tsx
@@ -23,6 +23,7 @@ import type { TdChatMessageActionName, TdChatMessageProps } from '../chat-messag
 import { TdChatSenderParams } from '../chat-sender';
 import type ChatSender from '../chat-sender/chat-sender';
 import { TdAttachmentItem } from '../filecard';
+import { createChatMessageAttachments } from './attachment';
 import type Chatlist from './chat-list';
 import type { TdChatbotApi, TdChatListScrollToOptions, TdChatMessageConfig, TdChatProps } from './type';
 
@@ -299,7 +300,7 @@ export default class Chatbot extends Component<TdChatProps> implements TdChatbot
     const { value, attachments } = e.detail;
     const params = {
       prompt: value,
-      attachments,
+      attachments: createChatMessageAttachments(attachments),
     } as ChatRequestParams;
     await this.sendUserMessage(params);
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ catalogs:
     vite:
       specifier: ^8.1.5
       version: 8.1.5
+    vitest:
+      specifier: ^4.1.10
+      version: 4.1.10
 
 overrides:
   '@commitlint/format': 20.5.0
@@ -187,6 +190,9 @@ importers:
       vite:
         specifier: catalog:tooling
         version: 8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.6.1)(less@4.8.0)(tsx@4.23.1)(yaml@2.8.3)
+      vitest:
+        specifier: catalog:tooling
+        version: 4.1.10(@types/node@22.20.1)(jsdom@19.0.0)(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.6.1)(less@4.8.0)(tsx@4.23.1)(yaml@2.8.3))
 
   packages/common/docs: {}
 
@@ -1041,6 +1047,9 @@ packages:
     resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
     engines: {node: '>=18'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/typography@0.5.20':
     resolution: {integrity: sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==}
     peerDependencies:
@@ -1063,6 +1072,9 @@ packages:
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/clipboard@2.0.10':
     resolution: {integrity: sha512-6CIsNdBfOTN92GHhQ0BaGY9KoV4DPH7ynCk5eggSDy3HW7OHLKWJUskL72uoVxl2kZ/XCq28TEgI0HKxLbRxyQ==}
@@ -1160,6 +1172,9 @@ packages:
 
   '@types/d3@7.4.3':
     resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -1270,6 +1285,35 @@ packages:
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@vue/compiler-core@3.5.40':
     resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
@@ -1508,6 +1552,10 @@ packages:
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -1599,6 +1647,10 @@ packages:
 
   caniuse-lite@1.0.30001806:
     resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -2114,6 +2166,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -2203,6 +2258,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2217,6 +2275,10 @@ packages:
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   expr-eval@2.0.2:
     resolution: {integrity: sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg==}
@@ -3048,6 +3110,9 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
@@ -3057,10 +3122,6 @@ packages:
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
@@ -3358,6 +3419,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -3384,9 +3448,15 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stream-parser@0.3.1:
     resolution: {integrity: sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==}
@@ -3496,6 +3566,9 @@ packages:
   tiny-emitter@2.1.0:
     resolution: {integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
@@ -3510,6 +3583,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3670,6 +3747,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue@2.7.14:
     resolution: {integrity: sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==}
     deprecated: Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.
@@ -3724,6 +3842,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -4475,6 +4598,8 @@ snapshots:
 
   '@simple-libs/stream-utils@1.2.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/typography@0.5.20(tailwindcss@3.4.19(tsx@4.23.1)(yaml@2.8.3))':
     dependencies:
       postcss-selector-parser: 6.0.10
@@ -4512,6 +4637,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/clipboard@2.0.10':
     dependencies:
@@ -4665,6 +4795,8 @@ snapshots:
       '@types/d3-zoom': 3.0.8
     optional: true
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.9': {}
@@ -4802,6 +4934,47 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
     optional: true
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.6.1)(less@4.8.0)(tsx@4.23.1)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.6.1)(less@4.8.0)(tsx@4.23.1)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
 
   '@vue/compiler-core@3.5.40':
     dependencies:
@@ -5006,6 +5179,8 @@ snapshots:
 
   array-ify@1.0.0: {}
 
+  assertion-error@2.0.1: {}
+
   asynckit@0.4.0: {}
 
   autoprefixer@10.5.4(postcss@8.5.22):
@@ -5097,6 +5272,8 @@ snapshots:
   caniuse-lite@1.0.30001788: {}
 
   caniuse-lite@1.0.30001806: {}
+
+  chai@6.2.2: {}
 
   chalk@5.6.2: {}
 
@@ -5642,6 +5819,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.3.2: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -5775,6 +5954,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -5792,6 +5975,8 @@ snapshots:
       onetime: 6.0.0
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
+
+  expect-type@1.4.0: {}
 
   expr-eval@2.0.2: {}
 
@@ -5855,9 +6040,9 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -6618,13 +6803,13 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
+  pathe@2.0.3: {}
+
   performance-now@2.1.0: {}
 
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
-
-  picomatch@4.0.4: {}
 
   picomatch@4.0.5: {}
 
@@ -6931,6 +7116,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   slice-ansi@5.0.0:
@@ -6951,7 +7138,11 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@4.2.0: {}
 
   stream-parser@0.3.1:
     dependencies:
@@ -7124,19 +7315,23 @@ snapshots:
 
   tiny-emitter@2.1.0: {}
 
+  tinybench@2.9.0: {}
+
   tinycolor2@1.6.0: {}
 
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -7279,6 +7474,34 @@ snapshots:
       tsx: 4.23.1
       yaml: 2.8.3
 
+  vitest@4.1.10(@types/node@22.20.1)(jsdom@19.0.0)(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.6.1)(less@4.8.0)(tsx@4.23.1)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.6.1)(less@4.8.0)(tsx@4.23.1)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.6.1)(less@4.8.0)(tsx@4.23.1)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.20.1
+      jsdom: 19.0.0
+    transitivePeerDependencies:
+      - msw
+
   vue@2.7.14:
     dependencies:
       '@vue/compiler-sfc': 2.7.14
@@ -7329,6 +7552,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,5 +44,6 @@ catalogs:
     typescript: ^6.0.3
     typescript-eslint: ^8.65.0
     vite: ^8.1.5
+    vitest: ^4.1.10
 
 shamefullyHoist: true

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['packages/**/*.{test,spec}.{js,jsx,mjs,cjs,ts,tsx}'],
+    exclude: ['packages/common/**', '**/node_modules/**', '**/{coverage,dist,esm}/**'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [x] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- https://github.com/TDesignOteam/tdesign-web-components/issues/381
- `develop` 已合并的对应修复：#411
- 已关闭的旧 `next` 方案：#410

### 💡 需求背景和解决方案

这是 `develop` #411 面向 monorepo `next` 的独立 forward-port，只迁移附件状态隔离的业务行为，不带入旧 #410 中的发布构建修改。

Vue 使用普通 `ref([])` 保存附件时，传入 Web Component 的 `TdAttachmentItem` 可能是 Vue Proxy。旧实现会把调用方的完整附件原引用写入 ChatEngine/Immer 消息状态并冻结，后续深层遍历可能触发 Proxy invariant 或 `Subscriber error`。

本 PR 修正数据所有权：

1. Sender 中的附件继续作为外部上传状态使用；
2. Chatbot 发送时按 ChatEngine `AttachmentItem` 契约创建新的消息附件 DTO；
3. `raw`、`response` 等上传过程对象不进入消息状态；
4. 每次发送创建独立快照，不持有或冻结调用方对象；
5. 根据 MIME 或扩展名补全 ChatEngine 所需的 `fileType`。

没有新增或删除公共 API，也不要求业务使用 `markRaw`。

验证结果：

- `pnpm test`：2/2 通过；覆盖不读取 `raw` / `response`、独立 DTO 和文件类型推断。
- `pnpm run check:types`：通过。
- `pnpm run check:pack`：通过；UI/Chat 发布文件、声明引用、ESM 导出和组件入口均通过。
- 修改文件的 ESLint、Prettier 和 `git diff --check`：通过。

### 📝 更新日志

- fix(Chat): 发送附件进入消息状态前创建独立 DTO，避免持有和冻结外部上传对象

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供


### 统一测试体系（`94d6a89`）

- 根命令统一为 `pnpm test`，直接执行 `vitest run`；本地监听使用 `pnpm run test:watch`。
- 根 `vitest.config.ts` 统一维护 test/spec 发现规则、Node 环境和构建产物排除项。
- `packages/common/**` 明确排除：它是独立 git submodule，拥有自己的 Vitest 依赖、配置和流水线。
- Vitest 版本由 pnpm tooling catalog 统一管理，当前为 `^4.1.10`，兼容仓库的 Node 22 与 Vite 8。
- 当前主仓库实际有 1 个测试文件、2 个附件所有权用例；后续组件测试无需再修改根测试命令。
