### PR TITLE
refactor(types): make WebC component exports explicit

### DIFF
--- a/packages/components/affix/index.ts
+++ b/packages/components/affix/index.ts
@@ -1,9 +1,10 @@
 import './style/index.js';
 
 import _Affix from './affix';
+import type { AffixRef, TdAffixProps } from './type';
+
+export type { AffixRef, TdAffixProps };
 
 export type { AffixProps } from './affix';
 export const Affix = _Affix;
 export default Affix;
-
-export * from './type';

--- a/packages/components/breadcrumb/index.ts
+++ b/packages/components/breadcrumb/index.ts
@@ -2,9 +2,9 @@ import './style/index.js';
 
 import _Breadcrumb from './breadcrumb';
 import _BreadcrumbItem from './breadcrumb-item';
+import type { TdBreadcrumbItemProps, TdBreadcrumbProps } from './type';
 
-export type { TdBreadcrumbItemProps, TdBreadcrumbProps } from './type';
-export * from './type';
+export type { TdBreadcrumbItemProps, TdBreadcrumbProps };
 export const Breadcrumb = _Breadcrumb;
 export const BreadcrumbItem = _BreadcrumbItem;
 export default Breadcrumb;

--- a/packages/components/button/index.ts
+++ b/packages/components/button/index.ts
@@ -1,9 +1,10 @@
 import './style/index.js';
 
 import _Button from './button';
+import type { TdButtonProps } from './type';
+
+export type { TdButtonProps };
 
 export type { ButtonProps } from './button';
 export const Button = _Button;
 export default Button;
-
-export * from './type';

--- a/packages/components/card/index.ts
+++ b/packages/components/card/index.ts
@@ -1,9 +1,10 @@
 import './style/index.js';
 
 import _Card from './card.jsx';
+import type { TdCardProps } from './type';
+
+export type { TdCardProps };
 
 export type { CardProps } from './card.jsx';
 export const Card = _Card;
 export default Card;
-
-export * from './type';

--- a/packages/components/checkbox/index.ts
+++ b/packages/components/checkbox/index.ts
@@ -2,14 +2,26 @@ import './style/index';
 
 import _Checkbox from './checkbox';
 import _Group from './checkbox-group';
-import type { TdCheckboxGroupProps, TdCheckboxProps } from './type';
+import type {
+  CheckboxGroupChangeContext,
+  CheckboxGroupValue,
+  CheckboxOption,
+  CheckboxOptionObj,
+  TdCheckboxGroupProps,
+  TdCheckboxProps,
+} from './type';
 
+export type {
+  CheckboxGroupChangeContext,
+  CheckboxGroupValue,
+  CheckboxOption,
+  CheckboxOptionObj,
+  TdCheckboxGroupProps,
+  TdCheckboxProps,
+};
 export type CheckboxProps = TdCheckboxProps;
 export type CheckboxGroupProps = TdCheckboxGroupProps;
 
 export const Checkbox = _Checkbox;
 export const CheckboxGroup = _Group;
-
-export * from './type';
-
 export default Checkbox;

--- a/packages/components/collapse/index.ts
+++ b/packages/components/collapse/index.ts
@@ -1,10 +1,11 @@
 import './style/index.js';
 
 import _Collapse from './collapse';
+import type { CollapsePanelValue, CollapseValue, TdCollapsePanelProps, TdCollapseProps } from './type';
+
+export type { CollapsePanelValue, CollapseValue, TdCollapsePanelProps, TdCollapseProps };
 
 export type { CollapseProps } from './collapse';
 export { default as CollapsePanel, type CollapsePanelProps } from './collapse-panel';
-export * from './type';
-
 export const Collapse = _Collapse;
 export default Collapse;

--- a/packages/components/date-picker/index.ts
+++ b/packages/components/date-picker/index.ts
@@ -2,6 +2,27 @@ import './style/index.js';
 
 import _DatePicker from './DatePicker';
 import _DateRangePicker from './DateRangePicker';
+import type {
+  DateRangeValue,
+  DateValue,
+  DisableDate,
+  DisableDateObject,
+  PresetDate,
+  PresetRange,
+  TdDatePickerProps,
+  TdDateRangePickerProps,
+} from './type';
+
+export type {
+  DateRangeValue,
+  DateValue,
+  DisableDate,
+  DisableDateObject,
+  PresetDate,
+  PresetRange,
+  TdDatePickerProps,
+  TdDateRangePickerProps,
+};
 
 export type { DatePickerProps } from './DatePicker';
 export type { DateRangePickerProps } from './DateRangePicker';
@@ -10,5 +31,3 @@ export const DatePicker = _DatePicker;
 export const DateRangePicker = _DateRangePicker;
 
 export default DatePicker;
-
-export * from './type';

--- a/packages/components/dialog/index.ts
+++ b/packages/components/dialog/index.ts
@@ -2,10 +2,31 @@ import './style/index.js';
 
 import _Dialog from './dialog';
 import { DialogPlugin as _DialogPlugin } from './plugin';
+import type {
+  DialogAlertMethod,
+  DialogCloseContext,
+  DialogConfirmMethod,
+  DialogEventSource,
+  DialogInstance,
+  DialogMethod,
+  DialogOptions,
+  TdDialogCardProps,
+  TdDialogProps,
+} from './type';
+
+export type {
+  DialogAlertMethod,
+  DialogCloseContext,
+  DialogConfirmMethod,
+  DialogEventSource,
+  DialogInstance,
+  DialogMethod,
+  DialogOptions,
+  TdDialogCardProps,
+  TdDialogProps,
+};
 
 export type { DialogProps } from './dialog';
-export * from './type';
-
 export const Dialog = _Dialog;
 export const dialog = _DialogPlugin;
 export const DialogPlugin = _DialogPlugin;

--- a/packages/components/divider/index.ts
+++ b/packages/components/divider/index.ts
@@ -1,9 +1,10 @@
 import './style/index.js';
 
 import _Divider from './divider';
+import type { TdDividerProps } from './type';
+
+export type { TdDividerProps };
 
 export type { DividerProps } from './divider';
-export * from './type';
-
 export const Divider = _Divider;
 export default Divider;

--- a/packages/components/dropdown/index.ts
+++ b/packages/components/dropdown/index.ts
@@ -1,10 +1,11 @@
 import './style/index.js';
 
 import _Dropdown from './dropdown';
+import type { DropdownItemTheme, DropdownOption, TdDropdownItemProps, TdDropdownProps } from './type';
+
+export type { DropdownItemTheme, DropdownOption, TdDropdownItemProps, TdDropdownProps };
 
 export type { DropdownProps } from './dropdown';
-export * from './type';
-
 export const Dropdown = _Dropdown;
 
 export default Dropdown;

--- a/packages/components/grid/index.ts
+++ b/packages/components/grid/index.ts
@@ -2,10 +2,11 @@ import './style/index.js';
 
 import _Col from './col';
 import _Row from './row';
+import type { BaseColProps, GutterObject, TdColProps, TdRowProps } from './type';
+
+export type { BaseColProps, GutterObject, TdColProps, TdRowProps };
 
 export type { ColProps } from './col';
 export type { RowProps } from './row';
-export * from './type';
-
 export const Row = _Row;
 export const Col = _Col;

--- a/packages/components/input/index.ts
+++ b/packages/components/input/index.ts
@@ -2,11 +2,12 @@ import './style/index';
 
 import _Input from './input';
 import _InputGroup from './input-group';
+import type { InputFormatType, InputValue, TdInputGroupProps, TdInputProps } from './type';
+
+export type { InputFormatType, InputValue, TdInputGroupProps, TdInputProps };
 
 export type { InputProps, InputRef } from './input';
 export type { InputGroupProps } from './input-group';
-export * from './type';
-
 export const Input = _Input;
 export const InputGroup = _InputGroup;
 export default { Input, InputGroup };

--- a/packages/components/loading/index.ts
+++ b/packages/components/loading/index.ts
@@ -2,10 +2,11 @@ import './style/index.js';
 
 import _Loading from './loading';
 import { LoadingPlugin as _LoadingPlugin } from './plugin';
+import type { LoadingInstance, LoadingMethod, TdLoadingProps } from './type';
+
+export type { LoadingInstance, LoadingMethod, TdLoadingProps };
 
 export type { LoadingProps } from './loading';
-export * from './type';
-
 export const Loading = _Loading;
 export const loading = _LoadingPlugin;
 export const LoadingPlugin = _LoadingPlugin;

--- a/packages/components/menu/index.ts
+++ b/packages/components/menu/index.ts
@@ -2,11 +2,12 @@ import './style/index.js';
 
 import _Menu from './Menu';
 import _MenuItem from './MenuItem';
+import type { MenuValue, TdMenuItemProps, TdMenuProps } from './type';
+
+export type { MenuValue, TdMenuItemProps, TdMenuProps };
 
 export type { MenuProps } from './Menu';
 export type { MenuItemProps } from './MenuItem';
-export * from './type';
-
 export const Menu = _Menu;
 export const MenuItem = _MenuItem;
 

--- a/packages/components/notification/index.ts
+++ b/packages/components/notification/index.ts
@@ -2,9 +2,39 @@ import './style/index.js';
 
 import _Notification from './Notification';
 import { NotificationPlugin as _NotificationPlugin } from './NotificationPlugin';
+import type {
+  NotificationCloseAllMethod,
+  NotificationCloseMethod,
+  NotificationConfigMethod,
+  NotificationErrorMethod,
+  NotificationInfoMethod,
+  NotificationInfoOptions,
+  NotificationInstance,
+  NotificationMethod,
+  NotificationOptions,
+  NotificationPlacementList,
+  NotificationSuccessMethod,
+  NotificationThemeList,
+  NotificationWarningMethod,
+  TdNotificationProps,
+} from './type';
 
-export * from './type';
-
+export type {
+  NotificationCloseAllMethod,
+  NotificationCloseMethod,
+  NotificationConfigMethod,
+  NotificationErrorMethod,
+  NotificationInfoMethod,
+  NotificationInfoOptions,
+  NotificationInstance,
+  NotificationMethod,
+  NotificationOptions,
+  NotificationPlacementList,
+  NotificationSuccessMethod,
+  NotificationThemeList,
+  NotificationWarningMethod,
+  TdNotificationProps,
+};
 export const Notification = _Notification;
 export const notification = _NotificationPlugin;
 export const NotificationPlugin = _NotificationPlugin;

--- a/packages/components/popconfirm/index.ts
+++ b/packages/components/popconfirm/index.ts
@@ -1,9 +1,10 @@
 import './style/index.js';
 
 import _Popconfirm from './popconfirm';
+import type { PopconfirmVisibleChangeContext, TdPopconfirmProps, TriggerSource } from './type';
+
+export type { PopconfirmVisibleChangeContext, TdPopconfirmProps, TriggerSource };
 
 export type { PopconfirmProps } from './popconfirm';
-export * from './type';
-
 export const Popconfirm = _Popconfirm;
 export default Popconfirm;

--- a/packages/components/popup/index.ts
+++ b/packages/components/popup/index.ts
@@ -1,9 +1,16 @@
 import './style/index.js';
 
 import _Popup from './popup';
+import type {
+  PopupPlacement,
+  PopupTriggerEvent,
+  PopupTriggerSource,
+  PopupVisibleChangeContext,
+  TdPopupProps,
+} from './type';
+
+export type { PopupPlacement, PopupTriggerEvent, PopupTriggerSource, PopupVisibleChangeContext, TdPopupProps };
 
 export type { PopupProps } from './popup';
-export * from './type';
-
 export const Popup = _Popup;
 export default Popup;

--- a/packages/components/progress/index.ts
+++ b/packages/components/progress/index.ts
@@ -1,9 +1,10 @@
 import './style/index.js';
 
 import _Progress from './progress';
+import type { StatusEnum, TdProgressProps, ThemeEnum } from './type';
+
+export type { StatusEnum, TdProgressProps, ThemeEnum };
 
 export type { ProgressProps } from './progress';
 export const Progress = _Progress;
 export default Progress;
-
-export * from './type';

--- a/packages/components/radio/index.ts
+++ b/packages/components/radio/index.ts
@@ -3,11 +3,12 @@ import './style/index.js';
 import _Radio from './radio';
 import _RadioButton from './radioButton.jsx';
 import _RadioGroup from './radioGroup.jsx';
+import type { RadioOption, RadioOptionObj, RadioValue, TdRadioGroupProps, TdRadioProps } from './type';
+
+export type { RadioOption, RadioOptionObj, RadioValue, TdRadioGroupProps, TdRadioProps };
 
 export type { RadioProps } from './radio';
 export type { RadioGroupProps } from './radioGroup';
-export * from './type';
-
 export const Radio = _Radio;
 export const RadioButton = _RadioButton;
 export const RadioGroup = _RadioGroup;

--- a/packages/components/range-input/index.ts
+++ b/packages/components/range-input/index.ts
@@ -2,10 +2,11 @@ import './style/index.js';
 
 import _RangeInput from './RangeInput.jsx';
 import _RangeInputPopup from './RangeInputPopup';
+import type { RangeInputPosition, RangeInputValue, TdRangeInputPopupProps, TdRangeInputProps } from './type';
+
+export type { RangeInputPosition, RangeInputValue, TdRangeInputPopupProps, TdRangeInputProps };
 
 export type { RangeInputProps } from './RangeInput.jsx';
-export * from './type';
-
 export const RangeInput = _RangeInput;
 export const RangeInputPopup = _RangeInputPopup;
 export default RangeInput;

--- a/packages/components/select/index.ts
+++ b/packages/components/select/index.ts
@@ -2,10 +2,31 @@ import './style/index.js';
 
 import _Option from './Option';
 import _Select from './Select';
+import type {
+  SelectContext,
+  SelectKeysType,
+  SelectOption,
+  SelectOptionGroup,
+  SelectRemoveContext,
+  SelectValue,
+  SelectValueChangeTrigger,
+  TdOptionGroupProps,
+  TdOptionProps,
+  TdSelectProps,
+} from './type';
 
-export type { SelectValue } from './type';
-export * from './type';
-
+export type {
+  SelectContext,
+  SelectKeysType,
+  SelectOption,
+  SelectOptionGroup,
+  SelectRemoveContext,
+  SelectValue,
+  SelectValueChangeTrigger,
+  TdOptionGroupProps,
+  TdOptionProps,
+  TdSelectProps,
+};
 export const Select = _Select;
 export const Option = _Option;
 

--- a/packages/components/skeleton/index.ts
+++ b/packages/components/skeleton/index.ts
@@ -1,9 +1,10 @@
 import './style/index';
 
 import _Skeleton from './skeleton';
+import type { SkeletonRowCol, SkeletonRowColObj, TdSkeletonProps } from './type';
+
+export type { SkeletonRowCol, SkeletonRowColObj, TdSkeletonProps };
 
 export type { SkeletonProps } from './skeleton';
-export * from './type';
-
 export const Skeleton = _Skeleton;
 export default Skeleton;

--- a/packages/components/slider/index.ts
+++ b/packages/components/slider/index.ts
@@ -1,9 +1,10 @@
 import './style/index.js';
 
 import _Slider from './slider';
+import type { SliderMarks, SliderValue, TdSliderProps } from './type';
+
+export type { SliderMarks, SliderValue, TdSliderProps };
 
 export type { SliderProps } from './slider';
-export * from './type';
-
 export const Slider = _Slider;
 export default Slider;

--- a/packages/components/swiper/index.ts
+++ b/packages/components/swiper/index.ts
@@ -1,10 +1,11 @@
 import './style/index';
 
 import _Swiper from './swiper';
+import type { SwiperChangeSource, SwiperNavigation, SwiperNavigationType, TdSwiperProps } from './type';
+
+export type { SwiperChangeSource, SwiperNavigation, SwiperNavigationType, TdSwiperProps };
 
 export type { SwiperProps } from './swiper';
 
 export const Swiper = _Swiper;
 export default Swiper;
-
-export * from './type';

--- a/packages/components/switch/index.ts
+++ b/packages/components/switch/index.ts
@@ -1,9 +1,10 @@
 import './style/index.js';
 
 import _Switch from './switch';
+import type { SwitchValue, TdSwitchProps } from './type';
+
+export type { SwitchValue, TdSwitchProps };
 
 export type { SwitchProps } from './switch';
-export * from './type';
-
 export const Switch = _Switch;
 export default Switch;

--- a/packages/components/tabs/index.ts
+++ b/packages/components/tabs/index.ts
@@ -1,11 +1,12 @@
 import './style/index.js';
 
 import _Tabs from './tabs';
+import type { TabsDragSortContext, TabValue, TdTabPanelProps, TdTabsProps } from './type';
+
+export type { TabsDragSortContext, TabValue, TdTabPanelProps, TdTabsProps };
 
 export type { TabPanelProps } from './tabPanel';
 export type { TabsProps } from './tabs';
 
 export const Tabs = _Tabs;
 export default Tabs;
-
-export * from './type';

--- a/packages/components/tag-input/index.ts
+++ b/packages/components/tag-input/index.ts
@@ -1,9 +1,28 @@
 import './style/index.js';
 
 import _TagInput from './tag-input.jsx';
+import type {
+  InputValueChangeContext,
+  TagInputChangeContext,
+  TagInputDragSortContext,
+  TagInputRemoveContext,
+  TagInputRemoveTrigger,
+  TagInputTriggerSource,
+  TagInputValue,
+  TdTagInputProps,
+} from './type';
+
+export type {
+  InputValueChangeContext,
+  TagInputChangeContext,
+  TagInputDragSortContext,
+  TagInputRemoveContext,
+  TagInputRemoveTrigger,
+  TagInputTriggerSource,
+  TagInputValue,
+  TdTagInputProps,
+};
 
 export type { TagInputProps } from './tag-input.jsx';
 export const TagInput = _TagInput;
 export default TagInput;
-
-export * from './type';

--- a/packages/components/tag/index.ts
+++ b/packages/components/tag/index.ts
@@ -1,8 +1,8 @@
 import './style/index.js';
 
 import _Tag from './tag';
+import type { CheckTagProps, TagProps } from './type';
 
-export * from './type';
-
+export type { CheckTagProps, TagProps };
 export const Tag = _Tag;
 export default Tag;

--- a/packages/components/textarea/index.ts
+++ b/packages/components/textarea/index.ts
@@ -1,9 +1,10 @@
 import './style/index.js';
 
 import _Textarea from './textarea';
+import type { TdTextareaProps, TextareaValue } from './type';
+
+export type { TdTextareaProps, TextareaValue };
 
 export type { TextareaProps } from './textarea';
 export const Textarea = _Textarea;
 export default Textarea;
-
-export * from './type';

--- a/packages/components/tooltip/index.ts
+++ b/packages/components/tooltip/index.ts
@@ -1,9 +1,10 @@
 import './style/index.js';
 
 import _Tooltip from './tooltip';
+import type { TdTooltipLiteProps, TdTooltipProps } from './type';
+
+export type { TdTooltipLiteProps, TdTooltipProps };
 
 export type { TooltipProps } from './tooltip';
-export * from './type';
-
 export const Tooltip = _Tooltip;
 export default Tooltip;

--- a/packages/components/upload/index.ts
+++ b/packages/components/upload/index.ts
@@ -1,8 +1,36 @@
 import './style/index.js';
 
+import type {
+  SizeUnit,
+  SizeUnitArray,
+  SuccessContext,
+  TdUploadProps,
+  UploadChangeContext,
+  UploadChangeTrigger,
+  UploadFailContext,
+  UploadFile,
+  UploadInstanceFunctions,
+  UploadProps,
+  UploadRemoveContext,
+  UploadSelectChangeContext,
+  UploadValidateType,
+} from './type';
 import _Upload from './upload';
 
-export * from './type';
-
+export type {
+  SizeUnit,
+  SizeUnitArray,
+  SuccessContext,
+  TdUploadProps,
+  UploadChangeContext,
+  UploadChangeTrigger,
+  UploadFailContext,
+  UploadFile,
+  UploadInstanceFunctions,
+  UploadProps,
+  UploadRemoveContext,
+  UploadSelectChangeContext,
+  UploadValidateType,
+};
 export const Upload = _Upload;
 export default Upload;

--- a/packages/pro-components/chat/attachments/index.ts
+++ b/packages/pro-components/chat/attachments/index.ts
@@ -1,8 +1,9 @@
 import './style/index.js';
 
 import _Attachments from './attachments';
+import type { TdAttachmentsProps } from './type';
+
+export type { TdAttachmentsProps };
 
 export const Attachments = _Attachments;
 export default Attachments;
-
-export * from './type';

--- a/packages/pro-components/chat/chat-action/index.ts
+++ b/packages/pro-components/chat/chat-action/index.ts
@@ -1,8 +1,9 @@
 import './style/index.js';
 
 import _Action from './action';
+import type { TdChatActionData, TdChatActionItem, TdChatActionProps, TdChatActionsName } from './type';
+
+export type { TdChatActionData, TdChatActionItem, TdChatActionProps, TdChatActionsName };
 
 export const ChatAction = _Action;
 export default ChatAction;
-
-export * from './type.js';

--- a/packages/pro-components/chat/chat-loading/index.ts
+++ b/packages/pro-components/chat/chat-loading/index.ts
@@ -1,8 +1,9 @@
 import './style/index.js';
 
 import _Loading from './loading';
+import type { ChatLoadingAnimationType, TdChatLoadingProps } from './type';
+
+export type { ChatLoadingAnimationType, TdChatLoadingProps };
 
 export const ChatLoading = _Loading;
 export default ChatLoading;
-
-export * from './type';

--- a/packages/pro-components/chat/chat-sender/index.ts
+++ b/packages/pro-components/chat/chat-sender/index.ts
@@ -1,8 +1,25 @@
 import './style/index.js';
 
 import _ChatSender from './chat-sender';
+import type {
+  TdChatSenderAction,
+  TdChatSenderActionName,
+  TdChatSenderApi,
+  TdChatSenderParams,
+  TdChatSenderProps,
+  TdChatSenderUploadProps,
+  UploadActionType,
+} from './type';
+
+export type {
+  TdChatSenderAction,
+  TdChatSenderActionName,
+  TdChatSenderApi,
+  TdChatSenderParams,
+  TdChatSenderProps,
+  TdChatSenderUploadProps,
+  UploadActionType,
+};
 
 export const ChatSender = _ChatSender;
 export default ChatSender;
-
-export * from './type';

--- a/packages/pro-components/chat/chatbot/index.ts
+++ b/packages/pro-components/chat/chatbot/index.ts
@@ -1,8 +1,45 @@
 import './style/index.js';
 
 import _Chat from './chat';
+import type {
+  BackBottomParams,
+  FetchSSEOptions,
+  Layout,
+  MetaData,
+  ModelRoleEnum,
+  ScrollPosition,
+  SSEEvent,
+  TdChatbotApi,
+  TdChatCodeProps,
+  TdChatInjectCSS,
+  TdChatListApi,
+  TdChatListProps,
+  TdChatListScrollToOptions,
+  TdChatMessageActionEvent,
+  TdChatMessageConfig,
+  TdChatMessageConfigItem,
+  TdChatProps,
+} from './type';
+
+export type {
+  BackBottomParams,
+  FetchSSEOptions,
+  Layout,
+  MetaData,
+  ModelRoleEnum,
+  ScrollPosition,
+  SSEEvent,
+  TdChatbotApi,
+  TdChatCodeProps,
+  TdChatInjectCSS,
+  TdChatListApi,
+  TdChatListProps,
+  TdChatListScrollToOptions,
+  TdChatMessageActionEvent,
+  TdChatMessageConfig,
+  TdChatMessageConfigItem,
+  TdChatProps,
+};
 
 export const Chat = _Chat;
-
-export * from './type';
 export default Chat;

--- a/packages/pro-components/chat/filecard/index.ts
+++ b/packages/pro-components/chat/filecard/index.ts
@@ -1,8 +1,9 @@
 import './style/index.js';
 
 import _Filecard from './filecard';
+import type { TdAttachmentItem, TdFileCardProps } from './type';
+
+export type { TdAttachmentItem, TdFileCardProps };
 
 export const Filecard = _Filecard;
 export default Filecard;
-
-export * from './type';


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- 依赖并叠加在 #409 上。
- 跨仓库进度见 [#409 跟踪评论](https://github.com/TDesignOteam/tdesign-web-components/pull/409#issuecomment-5353287428)。
- React 最终联调：[Tencent/tdesign-react#4362](https://github.com/Tencent/tdesign-react/pull/4362)。
- Vue Next 最终联调：[Tencent/tdesign-vue-next#6933](https://github.com/Tencent/tdesign-vue-next/pull/6933)。

### 💡 需求背景和解决方案

组件入口使用 `export * from './type'` 时，`type.ts` 未来新增的内部类型会自动进入公共 API。本 PR 将 31 个基础组件和 6 个 Chat 组件入口改为显式 type-only 导出清单。

- 保留现有公开类型名称，不改名、不删除、不新增组件能力。
- 不修改基础组件 Props、运行时实现和 common submodule。
- 不新增 ESLint/TypeScript ignore。
- 使用 `import type` + `export type` 兼容当前声明构建链。

验证结果：

- `pnpm run check:types`
- `pnpm run check:pack`
- 变更文件 ESLint、Prettier、`git diff --check`
- 自动核对显式清单覆盖各 `type.ts` 现有导出声明。
- 当前远端 CI 全部通过。

风险：预期没有用户侧 breaking change；真实 tarball 的 UI/Chat 根入口与组件 subpath 消费检查通过。React/Vue 当前仍使用 #409 做早期迁移验证，合并前必须切换到本 PR 的 `pkg.pr.new` 并重新执行完整 CI。#409 合并后，本 PR 再将 base 改回 `next`。

### 📝 更新日志

- refactor(types): 将 WebC 组件公共类型入口改为显式导出清单

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

