### PR TITLE
fix(chat): 修复 Shadow DOM 样式变量未生效

### DIFF
--- a/packages/pro-components/chat/__tests__/shadow-style-variables.test.ts
+++ b/packages/pro-components/chat/__tests__/shadow-style-variables.test.ts
@@ -2,27 +2,45 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
 
-const componentVariableFiles = [
+const globalVariableFiles = [
   '../chatbot/style/_var.less',
   '../chat-sender/style/_var.less',
   '../chat-action/style/_var.less',
   '../chat-message/style/_var.less',
+  '../attachments/style/_var.less',
+  '../chat-loading/style/_var.less',
 ];
 
-describe('chat Shadow DOM variables', () => {
-  test.each(componentVariableFiles)('%s declares component defaults on the host', (relativePath) => {
+const componentStyleEntries = [
+  '../chatbot/style/index.js',
+  '../chat-sender/style/index.js',
+  '../chat-action/style/index.js',
+  '../chat-message/style/index.js',
+  '../attachments/style/index.js',
+  '../chat-loading/style/index.js',
+  '../filecard/style/index.js',
+];
+
+describe('global Chat variables', () => {
+  test.each(globalVariableFiles)('%s declares defaults on the document root', (relativePath) => {
     const source = readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
 
-    expect(source).toMatch(/:host\s*\{/);
-    expect(source).not.toMatch(/:root\s*\{/);
+    expect(source).toMatch(/:root\s*\{/);
+    expect(source).not.toMatch(/:host\s*\{/);
   });
 
-  test('chat sender includes its variables in its own Shadow DOM stylesheet', () => {
-    const source = readFileSync(
-      fileURLToPath(new URL('../chat-sender/style/chat-sender.less', import.meta.url)),
-      'utf8',
-    );
+  test('the shared variable entry combines every distinct Chat variable group', () => {
+    const source = readFileSync(fileURLToPath(new URL('../style/variables.less', import.meta.url)), 'utf8');
 
-    expect(source).toMatch(/^@import\s+["']\.\/import\.less["'];/m);
+    expect(source).toContain('@import "../chatbot/style/_var.less";');
+    expect(source).toContain('@import "../chat-sender/style/_var.less";');
+    expect(source).toContain('@import "../attachments/style/_var.less";');
+    expect(source).toContain('@import "../chat-loading/style/_var.less";');
+  });
+
+  test.each(componentStyleEntries)('%s registers the shared variables for on-demand imports', (relativePath) => {
+    const source = readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
+
+    expect(source).toContain("import '../../style/variables.js';");
   });
 });

--- a/packages/pro-components/chat/__tests__/shadow-style-variables.test.ts
+++ b/packages/pro-components/chat/__tests__/shadow-style-variables.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'vitest';
+
+const componentVariableFiles = [
+  '../chatbot/style/_var.less',
+  '../chat-sender/style/_var.less',
+  '../chat-action/style/_var.less',
+  '../chat-message/style/_var.less',
+];
+
+describe('chat Shadow DOM variables', () => {
+  test.each(componentVariableFiles)('%s declares component defaults on the host', (relativePath) => {
+    const source = readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
+
+    expect(source).toMatch(/:host\s*\{/);
+    expect(source).not.toMatch(/:root\s*\{/);
+  });
+
+  test('chat sender includes its variables in its own Shadow DOM stylesheet', () => {
+    const source = readFileSync(
+      fileURLToPath(new URL('../chat-sender/style/chat-sender.less', import.meta.url)),
+      'utf8',
+    );
+
+    expect(source).toMatch(/^@import\s+["']\.\/import\.less["'];/m);
+  });
+});

--- a/packages/pro-components/chat/__tests__/shadow-style-variables.test.ts
+++ b/packages/pro-components/chat/__tests__/shadow-style-variables.test.ts
@@ -21,21 +21,41 @@ const componentStyleEntries = [
   '../filecard/style/index.js',
 ];
 
+const componentLessEntries = [
+  '../chatbot/style/import.less',
+  '../chat-sender/style/import.less',
+  '../chat-action/style/import.less',
+  '../chat-message/style/import.less',
+  '../attachments/style/import.less',
+  '../chat-loading/style/import.less',
+  '../filecard/style/import.less',
+];
+
 describe('global Chat variables', () => {
   test.each(globalVariableFiles)('%s declares defaults on the document root', (relativePath) => {
     const source = readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
 
-    expect(source).toMatch(/:root\s*\{/);
+    expect(source).toMatch(/:where\(:root\)\s*\{/);
+    expect(source).not.toMatch(/(^|[^:(])\b:root\s*\{/m);
     expect(source).not.toMatch(/:host\s*\{/);
   });
+
+  test.each(componentLessEntries)(
+    '%s references variables without emitting root rules in Shadow CSS',
+    (relativePath) => {
+      const source = readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
+
+      expect(source).toMatch(/@import\s+\(reference\)\s+['"]\.\/_var\.less['"];/);
+    },
+  );
 
   test('the shared variable entry combines every distinct Chat variable group', () => {
     const source = readFileSync(fileURLToPath(new URL('../style/variables.less', import.meta.url)), 'utf8');
 
-    expect(source).toContain('@import "../chatbot/style/_var.less";');
-    expect(source).toContain('@import "../chat-sender/style/_var.less";');
-    expect(source).toContain('@import "../attachments/style/_var.less";');
-    expect(source).toContain('@import "../chat-loading/style/_var.less";');
+    expect(source).toMatch(/@import\s+['"]\.\.\/chatbot\/style\/_var\.less['"];/);
+    expect(source).toMatch(/@import\s+['"]\.\.\/chat-sender\/style\/_var\.less['"];/);
+    expect(source).toMatch(/@import\s+['"]\.\.\/attachments\/style\/_var\.less['"];/);
+    expect(source).toMatch(/@import\s+['"]\.\.\/chat-loading\/style\/_var\.less['"];/);
   });
 
   test.each(componentStyleEntries)('%s registers the shared variables for on-demand imports', (relativePath) => {

--- a/packages/pro-components/chat/attachments/style/_var.less
+++ b/packages/pro-components/chat/attachments/style/_var.less
@@ -12,7 +12,7 @@
 // 如：@button-line-height-s
 
 
-:host {
+:root {
   --td-attachment-scroll-btn-wh: 24px;
   --td-attachment-scroll-btn-border: 1px solid var(--td-component-border);
   --td-attachment-scroll-btn-bgc: var(--td-bg-color-container);
@@ -26,5 +26,4 @@
 @attachment-arrow-left: 5px;
 
 @attachment-arrow-opacity: 0.6;
-
 

--- a/packages/pro-components/chat/attachments/style/_var.less
+++ b/packages/pro-components/chat/attachments/style/_var.less
@@ -11,8 +11,7 @@
 // 如：@button-line-bg-color-hover
 // 如：@button-line-height-s
 
-
-:root {
+:where(:root) {
   --td-attachment-scroll-btn-wh: 24px;
   --td-attachment-scroll-btn-border: 1px solid var(--td-component-border);
   --td-attachment-scroll-btn-bgc: var(--td-bg-color-container);
@@ -26,4 +25,3 @@
 @attachment-arrow-left: 5px;
 
 @attachment-arrow-opacity: 0.6;
-

--- a/packages/pro-components/chat/attachments/style/import.less
+++ b/packages/pro-components/chat/attachments/style/import.less
@@ -1,6 +1,6 @@
 @import "@common/style/web/base.less";
 
-@import "./_var.less";
+@import (reference) "./_var.less";
 
 @import "./_mixin.less";
 

--- a/packages/pro-components/chat/attachments/style/index.js
+++ b/packages/pro-components/chat/attachments/style/index.js
@@ -1,6 +1,7 @@
+import '../../style/variables.js';
+
 import { css, globalCSS } from 'omi';
 
-import '../../style/variables.js';
 // 为了做主题切换
 import styles from './_index.less';
 

--- a/packages/pro-components/chat/attachments/style/index.js
+++ b/packages/pro-components/chat/attachments/style/index.js
@@ -1,5 +1,6 @@
 import { css, globalCSS } from 'omi';
 
+import '../../style/variables.js';
 // 为了做主题切换
 import styles from './_index.less';
 

--- a/packages/pro-components/chat/chat-action/style/_var.less
+++ b/packages/pro-components/chat/chat-action/style/_var.less
@@ -11,7 +11,7 @@
 // 如：@button-line-bg-color-hover
 // 如：@button-line-height-s
 
-:root {
+:host {
   // 盒模型
   --td-chat-item-actions-list-gap: var(--td-comp-margin-xs);
   --td-chat-item-actions-list-padding: var(--td-comp-paddingTB-xs) var(--td-comp-paddingLR-xs);
@@ -24,6 +24,5 @@
   --td-chat-item-actions-list-bg: var(--td-bg-color-secondarycontainer);
   --td-chat-item-actions-item-hover-bg: var(--td-bg-color-component-hover);
 }
-
 
 

--- a/packages/pro-components/chat/chat-action/style/_var.less
+++ b/packages/pro-components/chat/chat-action/style/_var.less
@@ -11,7 +11,7 @@
 // 如：@button-line-bg-color-hover
 // 如：@button-line-height-s
 
-:host {
+:root {
   // 盒模型
   --td-chat-item-actions-list-gap: var(--td-comp-margin-xs);
   --td-chat-item-actions-list-padding: var(--td-comp-paddingTB-xs) var(--td-comp-paddingLR-xs);
@@ -24,5 +24,4 @@
   --td-chat-item-actions-list-bg: var(--td-bg-color-secondarycontainer);
   --td-chat-item-actions-item-hover-bg: var(--td-bg-color-component-hover);
 }
-
 

--- a/packages/pro-components/chat/chat-action/style/_var.less
+++ b/packages/pro-components/chat/chat-action/style/_var.less
@@ -11,7 +11,7 @@
 // 如：@button-line-bg-color-hover
 // 如：@button-line-height-s
 
-:root {
+:where(:root) {
   // 盒模型
   --td-chat-item-actions-list-gap: var(--td-comp-margin-xs);
   --td-chat-item-actions-list-padding: var(--td-comp-paddingTB-xs) var(--td-comp-paddingLR-xs);
@@ -24,4 +24,3 @@
   --td-chat-item-actions-list-bg: var(--td-bg-color-secondarycontainer);
   --td-chat-item-actions-item-hover-bg: var(--td-bg-color-component-hover);
 }
-

--- a/packages/pro-components/chat/chat-action/style/import.less
+++ b/packages/pro-components/chat/chat-action/style/import.less
@@ -1,6 +1,6 @@
 @import "@common/style/web/base.less";
 
-@import "./_var.less";
+@import (reference) "./_var.less";
 
 @import "./_mixin.less";
 

--- a/packages/pro-components/chat/chat-action/style/index.js
+++ b/packages/pro-components/chat/chat-action/style/index.js
@@ -1,6 +1,7 @@
+import '../../style/variables.js';
+
 import { css, globalCSS } from 'omi';
 
-import '../../style/variables.js';
 // 为了做主题切换
 import styles from './_index.less';
 

--- a/packages/pro-components/chat/chat-action/style/index.js
+++ b/packages/pro-components/chat/chat-action/style/index.js
@@ -1,5 +1,6 @@
 import { css, globalCSS } from 'omi';
 
+import '../../style/variables.js';
 // 为了做主题切换
 import styles from './_index.less';
 

--- a/packages/pro-components/chat/chat-loading/style/_var.less
+++ b/packages/pro-components/chat/chat-loading/style/_var.less
@@ -11,8 +11,7 @@
 // 如：@button-line-bg-color-hover
 // 如：@button-line-height-s
 
-
-:root {
+:where(:root) {
   --td-chat-loading-circle-width: 16px;
   --td-chat-loading-circle-height: 16px;
   --td-chat-loading-moving-width: 14px;
@@ -22,5 +21,3 @@
   --td-chat-loading-circle-border: 2px solid #e0f0ff;
   --td-chat-loading-border-radius: 50%;
 }
-
-

--- a/packages/pro-components/chat/chat-loading/style/_var.less
+++ b/packages/pro-components/chat/chat-loading/style/_var.less
@@ -12,7 +12,7 @@
 // 如：@button-line-height-s
 
 
-:host {
+:root {
   --td-chat-loading-circle-width: 16px;
   --td-chat-loading-circle-height: 16px;
   --td-chat-loading-moving-width: 14px;
@@ -22,6 +22,5 @@
   --td-chat-loading-circle-border: 2px solid #e0f0ff;
   --td-chat-loading-border-radius: 50%;
 }
-
 
 

--- a/packages/pro-components/chat/chat-loading/style/import.less
+++ b/packages/pro-components/chat/chat-loading/style/import.less
@@ -1,6 +1,6 @@
 @import "@common/style/web/base.less";
 
-@import "./_var.less";
+@import (reference) "./_var.less";
 
 @import "./_mixin.less";
 

--- a/packages/pro-components/chat/chat-loading/style/index.js
+++ b/packages/pro-components/chat/chat-loading/style/index.js
@@ -1,6 +1,7 @@
+import '../../style/variables.js';
+
 import { css, globalCSS } from 'omi';
 
-import '../../style/variables.js';
 // 为了做主题切换
 import styles from './_index.less';
 

--- a/packages/pro-components/chat/chat-loading/style/index.js
+++ b/packages/pro-components/chat/chat-loading/style/index.js
@@ -1,5 +1,6 @@
 import { css, globalCSS } from 'omi';
 
+import '../../style/variables.js';
 // 为了做主题切换
 import styles from './_index.less';
 

--- a/packages/pro-components/chat/chat-message/style/_var.less
+++ b/packages/pro-components/chat/chat-message/style/_var.less
@@ -13,7 +13,7 @@
 
 @import "@common/style/web/components/chat/_var.less";
 
-:root {
+:host {
   // 盒模型
   --td-chat-item-gap: 38px;
   --td-chat-item-header-padding: 0;

--- a/packages/pro-components/chat/chat-message/style/_var.less
+++ b/packages/pro-components/chat/chat-message/style/_var.less
@@ -13,7 +13,7 @@
 
 @import "@common/style/web/components/chat/_var.less";
 
-:root {
+:where(:root) {
   // 盒模型
   --td-chat-item-gap: 38px;
   --td-chat-item-header-padding: 0;

--- a/packages/pro-components/chat/chat-message/style/_var.less
+++ b/packages/pro-components/chat/chat-message/style/_var.less
@@ -13,7 +13,7 @@
 
 @import "@common/style/web/components/chat/_var.less";
 
-:host {
+:root {
   // 盒模型
   --td-chat-item-gap: 38px;
   --td-chat-item-header-padding: 0;

--- a/packages/pro-components/chat/chat-message/style/import.less
+++ b/packages/pro-components/chat/chat-message/style/import.less
@@ -2,6 +2,6 @@
 
 @import "@common/style/web/components/chat/_var.less";
 
-@import "./_var.less";
+@import (reference) "./_var.less";
 
 @import "./_mixin.less";

--- a/packages/pro-components/chat/chat-message/style/index.js
+++ b/packages/pro-components/chat/chat-message/style/index.js
@@ -1,5 +1,6 @@
 import { css, globalCSS } from 'omi';
 
+import '../../style/variables.js';
 import styles from './_index.less';
 import cherryIconFont from './cherry-icon-font.less';
 

--- a/packages/pro-components/chat/chat-message/style/index.js
+++ b/packages/pro-components/chat/chat-message/style/index.js
@@ -1,6 +1,7 @@
+import '../../style/variables.js';
+
 import { css, globalCSS } from 'omi';
 
-import '../../style/variables.js';
 import styles from './_index.less';
 import cherryIconFont from './cherry-icon-font.less';
 

--- a/packages/pro-components/chat/chat-sender/style/_var.less
+++ b/packages/pro-components/chat/chat-sender/style/_var.less
@@ -1,6 +1,6 @@
 @import "@common/style/web/components/chat/_var.less";
 
-:root {
+:where(:root) {
   // 盒模型
   --td-chat-input-attachments-margin: 0 0 var(--td-comp-margin-xs) 0;
   --td-chat-input-textarea-max-height: 134px;

--- a/packages/pro-components/chat/chat-sender/style/_var.less
+++ b/packages/pro-components/chat/chat-sender/style/_var.less
@@ -1,6 +1,6 @@
 @import "@common/style/web/components/chat/_var.less";
 
-:root {
+:host {
   // 盒模型
   --td-chat-input-attachments-margin: 0 0 var(--td-comp-margin-xs) 0;
   --td-chat-input-textarea-max-height: 134px;

--- a/packages/pro-components/chat/chat-sender/style/_var.less
+++ b/packages/pro-components/chat/chat-sender/style/_var.less
@@ -1,6 +1,6 @@
 @import "@common/style/web/components/chat/_var.less";
 
-:host {
+:root {
   // 盒模型
   --td-chat-input-attachments-margin: 0 0 var(--td-comp-margin-xs) 0;
   --td-chat-input-textarea-max-height: 134px;

--- a/packages/pro-components/chat/chat-sender/style/chat-sender.less
+++ b/packages/pro-components/chat/chat-sender/style/chat-sender.less
@@ -1,4 +1,4 @@
-@import "./import.less";
+@import "@common/style/web/base.less";
 
 :host {
   width: 100%;

--- a/packages/pro-components/chat/chat-sender/style/chat-sender.less
+++ b/packages/pro-components/chat/chat-sender/style/chat-sender.less
@@ -1,4 +1,4 @@
-@import "@common/style/web/base.less";
+@import "./import.less";
 
 :host {
   width: 100%;

--- a/packages/pro-components/chat/chat-sender/style/import.less
+++ b/packages/pro-components/chat/chat-sender/style/import.less
@@ -2,4 +2,4 @@
 
 @import "@common/style/web/components/chat/_var.less";
 
-@import "./_var.less";
+@import (reference) "./_var.less";

--- a/packages/pro-components/chat/chat-sender/style/index.js
+++ b/packages/pro-components/chat/chat-sender/style/index.js
@@ -1,6 +1,7 @@
+import '../../style/variables.js';
+
 import { css, globalCSS } from 'omi';
 
-import '../../style/variables.js';
 // 为了做主题切换
 import styles from './_index.less';
 

--- a/packages/pro-components/chat/chat-sender/style/index.js
+++ b/packages/pro-components/chat/chat-sender/style/index.js
@@ -1,5 +1,6 @@
 import { css, globalCSS } from 'omi';
 
+import '../../style/variables.js';
 // 为了做主题切换
 import styles from './_index.less';
 

--- a/packages/pro-components/chat/chatbot/style/_var.less
+++ b/packages/pro-components/chat/chatbot/style/_var.less
@@ -13,7 +13,7 @@
 
 @import "@common/style/web/components/chat/_var.less";
 
-:root {
+:host {
   // 盒模型
   --td-chat-list-padding-bottom: 0;
   --td-chat-list-scroll-button-top: calc(100% - 64px);

--- a/packages/pro-components/chat/chatbot/style/_var.less
+++ b/packages/pro-components/chat/chatbot/style/_var.less
@@ -13,7 +13,7 @@
 
 @import "@common/style/web/components/chat/_var.less";
 
-:root {
+:where(:root) {
   // 盒模型
   --td-chat-list-padding-bottom: 0;
   --td-chat-list-scroll-button-top: calc(100% - 64px);
@@ -200,11 +200,12 @@
   --td-chat-md-blockquote-border-left: 4px solid #d9d9d9;
   --td-chat-md-blockquote-color: var(--td-gray-color-7);
 
+
   --td-chat-md-footnote-bg: var(--td-bg-color-page);
-  
+
   --td-chat-md-hr-margin: 16px 0;
   --td-chat-md-hr-border: 1px solid rgba(0, 0, 0, 0.08);
-  
+
   --td-chat-md-table-border: 1px solid var(--td-bg-color-secondarycontainer);
   --td-chat-md-table-radius: 8px;
   --td-chat-md-table-margin: 8px 0;

--- a/packages/pro-components/chat/chatbot/style/_var.less
+++ b/packages/pro-components/chat/chatbot/style/_var.less
@@ -13,7 +13,7 @@
 
 @import "@common/style/web/components/chat/_var.less";
 
-:host {
+:root {
   // 盒模型
   --td-chat-list-padding-bottom: 0;
   --td-chat-list-scroll-button-top: calc(100% - 64px);

--- a/packages/pro-components/chat/chatbot/style/import.less
+++ b/packages/pro-components/chat/chatbot/style/import.less
@@ -2,4 +2,4 @@
 
 @import "@common/style/web/components/chat/_var.less";
 
-@import "./_var.less";
+@import (reference) "./_var.less";

--- a/packages/pro-components/chat/chatbot/style/index.js
+++ b/packages/pro-components/chat/chatbot/style/index.js
@@ -1,5 +1,6 @@
 import { css, globalCSS } from 'omi';
 
+import '../../style/variables.js';
 import styles from './_index.less';
 
 export const styleSheet = css`

--- a/packages/pro-components/chat/chatbot/style/index.js
+++ b/packages/pro-components/chat/chatbot/style/index.js
@@ -1,6 +1,7 @@
+import '../../style/variables.js';
+
 import { css, globalCSS } from 'omi';
 
-import '../../style/variables.js';
 import styles from './_index.less';
 
 export const styleSheet = css`

--- a/packages/pro-components/chat/filecard/style/import.less
+++ b/packages/pro-components/chat/filecard/style/import.less
@@ -1,6 +1,6 @@
 @import "@common/style/web/base.less";
 
-@import "./_var.less";
+@import (reference) "./_var.less";
 
 @import "./_mixin.less";
 

--- a/packages/pro-components/chat/filecard/style/index.js
+++ b/packages/pro-components/chat/filecard/style/index.js
@@ -1,6 +1,7 @@
+import '../../style/variables.js';
+
 import { css, globalCSS } from 'omi';
 
-import '../../style/variables.js';
 // 为了做主题切换
 import styles from './_index.less';
 

--- a/packages/pro-components/chat/filecard/style/index.js
+++ b/packages/pro-components/chat/filecard/style/index.js
@@ -1,5 +1,6 @@
 import { css, globalCSS } from 'omi';
 
+import '../../style/variables.js';
 // 为了做主题切换
 import styles from './_index.less';
 

--- a/packages/pro-components/chat/style/variables.js
+++ b/packages/pro-components/chat/style/variables.js
@@ -1,0 +1,10 @@
+import variables from './variables.less';
+
+export const chatVariablesStyleId = 'tdesign-wc-chat-variables';
+
+if (typeof document !== 'undefined' && !document.getElementById(chatVariablesStyleId)) {
+  const style = document.createElement('style');
+  style.id = chatVariablesStyleId;
+  style.textContent = variables;
+  document.head.appendChild(style);
+}

--- a/packages/pro-components/chat/style/variables.less
+++ b/packages/pro-components/chat/style/variables.less
@@ -1,0 +1,4 @@
+@import "../chatbot/style/_var.less";
+@import "../chat-sender/style/_var.less";
+@import "../attachments/style/_var.less";
+@import "../chat-loading/style/_var.less";


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 组件重构
- [x] 测试用例
- [ ] 工程化改造
- [ ] 代码风格更新
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

暂无。

### 💡 需求背景和解决方案

Vite 8 分包后，组件样式通过 `?inline` 注入各自的 Shadow Root。Chat 组件变量仍声明在 `:root` 中，因此这些声明不再注册到文档根节点，Shadow DOM 内依赖变量的样式回退失效，示例出现输入框、操作按钮等样式缺失。

本 PR 保留 Chat CSS 变量的全局 `:root` 语义，并统一处理当前 Chat 组件变量：

- 聚合 Chatbot、ChatSender、Attachments、ChatLoading 的变量文件（ChatMessage、ChatAction 的变量已包含在 Chatbot 变量集合中）；
- 通过共享入口将变量样式只注册一次到 `document.head`；
- 默认变量使用 `:where(:root)` 降低选择器权重，用户的 `:root`、`t-chatbot` 或子组件变量覆盖不再依赖样式加载顺序；
- 组件内部通过 Less `@import (reference)` 使用变量文件，避免将全局变量声明重复输出到每个 Shadow Root；
- Chat 的完整引入和各组件按需样式入口都会触发该注册；
- 用户仍可在 `:root`、`t-chatbot` 或具体子组件上覆盖变量，变量会按 CSS 自定义属性继承规则穿透 Shadow DOM；
- 添加回归测试，约束变量保持全局声明、变量集合完整且所有按需入口均引入共享注册模块。

本地验证：

- Chat 样式变量回归测试：21 个用例全部通过；
- Chat 站点构建通过；
- `pnpm run build:chat` 通过，并确认 ESM/IIFE 产物包含全局变量注册逻辑。

- [ ] 本条 PR 不需要纳入 Changelog

#### @tdesign/web-components

无用户可感知变更。

#### @tdesign/web-components-chat

- fix(Chat): 修复分包后 Chat CSS 变量未注册到全局导致默认样式及用户变量覆盖不生效的问题。

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
