### PR TITLE
fix(chat): preserve scoped component registration

### DIFF
--- a/packages/tdesign-web-components-chat/package.json
+++ b/packages/tdesign-web-components-chat/package.json
@@ -50,6 +50,7 @@
   ],
   "sideEffects": [
     "dist/**",
+    "esm/**",
     "**/style/**",
     "**/*.css"
   ],


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无。

### 💡 需求背景和解决方案

`@tdesign/web-components-chat` 的 ESM 组件入口会在模块执行时注册 Custom Element，但当前 `sideEffects` 未覆盖 `esm/**`。下游应用通过 `import '@tdesign/web-components-chat/chatbot'` 按需引入时，生产构建可能移除该导入，导致 `<t-chatbot>` 未注册且内容不渲染。

本 PR 将 Chat 包的 ESM 产物标记为有副作用，确保已按需引入的组件保留注册逻辑，不会被生产构建错误移除。

验证：

- `pnpm run build:chat`

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### @tdesign/web-components

无。

#### @tdesign/web-components-chat

- fix(Chatbot): 修复按需引入时生产构建可能移除组件注册的问题

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
