### PR TITLE
fix(chat): restore base component styles after split

### DIFF
--- a/packages/components/collapse/collapse-panel.tsx
+++ b/packages/components/collapse/collapse-panel.tsx
@@ -2,6 +2,7 @@ import '@tdesign/web-components-shared/common/fake-arrow';
 import 'omi-transition';
 
 import classname, { classPrefix } from '@tdesign/web-components-shared/_util/classname';
+import { setExportparts } from '@tdesign/web-components-shared/_util/dom';
 import { StyledProps, TNode } from '@tdesign/web-components-shared/common';
 import { bind, Component, computed, signal, tag } from 'omi';
 
@@ -58,6 +59,10 @@ export default class CollapsePanel extends Component<TdCollapsePanelProps> {
     this.isDisabled = computed(() => this.props.disabled || this.injection.disabled.value);
   }
 
+  ready(): void {
+    setExportparts(this);
+  }
+
   inject = [
     'getUniqId',
     'getCollapseValue',
@@ -109,6 +114,7 @@ export default class CollapsePanel extends Component<TdCollapsePanelProps> {
     return (
       <div
         className={classname(`${className}__icon`, [`${className}__icon--${expandIconPlacement.value}`])}
+        part={`${className}__icon`}
         onClick={this.handleClick}
       >
         {typeof this.props.expandIcon !== 'boolean' ? (
@@ -133,6 +139,7 @@ export default class CollapsePanel extends Component<TdCollapsePanelProps> {
         className={classname(`${className}__header`, {
           [`${classPrefix}-is-clickable`]: expandOnRowClick?.value && !this.isDisabled.value,
         })}
+        part={`${className}__header`}
         onClick={(e) => this.handleClick(e, true)}
       >
         <div className={`${className}__header-left`}>{expandIconPlacement?.value === 'left' && this.renderIcon()}</div>
@@ -174,9 +181,10 @@ export default class CollapsePanel extends Component<TdCollapsePanelProps> {
           afterLeave: this.afterLeave,
         }}
         className={`${className}__body`}
+        part={`${className}__body`}
         show={isActive}
       >
-        <div className={`${className}__content`}>
+        <div className={`${className}__content`} part={`${className}__content`}>
           <slot>{this.props.content}</slot>
         </div>
       </div>

--- a/packages/components/collapse/collapse.tsx
+++ b/packages/components/collapse/collapse.tsx
@@ -1,4 +1,5 @@
 import classname, { classPrefix } from '@tdesign/web-components-shared/_util/classname';
+import { setExportparts } from '@tdesign/web-components-shared/_util/dom';
 import { StyledProps, TNode } from '@tdesign/web-components-shared/common';
 import { bind, Component, OmiProps, signal, tag } from 'omi';
 
@@ -111,6 +112,10 @@ export default class Collapse extends Component<TdCollapseProps> {
     }
   }
 
+  ready(): void {
+    setExportparts(this);
+  }
+
   render(props: OmiProps<CollapseProps>): TNode {
     const { innerClass, innerStyle, borderless } = props;
 
@@ -123,7 +128,7 @@ export default class Collapse extends Component<TdCollapseProps> {
     );
 
     return (
-      <div className={classes} style={innerStyle}>
+      <div className={classes} style={innerStyle} part={`${classPrefix}-collapse`}>
         <slot></slot>
       </div>
     );

--- a/packages/tdesign-web-components/package.json
+++ b/packages/tdesign-web-components/package.json
@@ -49,6 +49,7 @@
   ],
   "sideEffects": [
     "dist/**",
+    "esm/**",
     "**/style/**",
     "**/*.css"
   ],


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- 关联 #418

### 💡 需求背景和解决方案

分包后的 Chat 消费场景中，基础包 ESM 模块会被构建器 tree-shaking，导致 `Textarea` 等基础 Web Components 未注册，Chatbot 输入框无法聚焦。同时，Chat Thinking/Search 通过 `::part` 定制 Collapse 样式，但 Collapse 尚未暴露对应 parts，造成默认边框样式泄漏。

本 PR：

- 将基础包 `esm/**` 标记为有副作用，保留组件注册。
- 为 Collapse 和 CollapsePanel 暴露 Chat 已使用的 `part`，并通过 `exportparts` 向外透出。

### 🧪 验证

- `pnpm exec prettier --check packages/components/collapse/collapse.tsx packages/components/collapse/collapse-panel.tsx packages/tdesign-web-components/package.json`
- `pnpm run build:ui`
- Vue Chatbot 本地产物预览：输入框可聚焦，Thinking/Search 恢复圆角无边框样式。

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### @tdesign/web-components

- fix(Chat): 修复分包后 Chatbot 输入交互和 Thinking/Search 样式异常

#### @tdesign/web-components-chat

- 无

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
