### PR TITLE
chore(deps): upgrade ai chat engine to 0.0.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: ^2.11.8
       version: 2.11.8
     '@tdesign/ai-chat-engine':
-      specifier: ^0.0.2
-      version: 0.0.2
+      specifier: ^0.0.3
+      version: 0.0.3
     cherry-markdown:
       specifier: 0.11.8
       version: 0.11.8
@@ -229,7 +229,7 @@ importers:
     dependencies:
       '@tdesign/ai-chat-engine':
         specifier: catalog:runtime
-        version: 0.0.2(immer@10.2.0)
+        version: 0.0.3(immer@10.2.0)
       cherry-markdown:
         specifier: catalog:runtime
         version: 0.11.8
@@ -299,7 +299,7 @@ importers:
     dependencies:
       '@tdesign/ai-chat-engine':
         specifier: catalog:runtime
-        version: 0.0.2(immer@10.2.0)
+        version: 0.0.3(immer@10.2.0)
       '@tdesign/web-components':
         specifier: workspace:^
         version: link:../tdesign-web-components
@@ -1044,8 +1044,8 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || >=4.0.0 || insiders'
 
-  '@tdesign/ai-chat-engine@0.0.2':
-    resolution: {integrity: sha512-CS6ubPz2f9c1kstu+a4oHpvIs08TPg5XbNBcYdd58od4bY+pu3q3/zYZsYCSD1i70E9pUimH6KTQ3oJusnalfw==}
+  '@tdesign/ai-chat-engine@0.0.3':
+    resolution: {integrity: sha512-iJwWXNBQH1L7pQjCpfkkoKbRlrcm/q61ChbSai4WnSJ8+TuB4To8K199VjG0j+xhuz4uD/L3PCcZ6/2XfrjVnw==}
     peerDependencies:
       immer: ^10.0.0
 
@@ -2275,9 +2275,6 @@ packages:
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
-
-  expr-eval@2.0.2:
-    resolution: {integrity: sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg==}
 
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
@@ -4580,10 +4577,9 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 3.4.19(tsx@4.23.1)(yaml@2.8.3)
 
-  '@tdesign/ai-chat-engine@0.0.2(immer@10.2.0)':
+  '@tdesign/ai-chat-engine@0.0.3(immer@10.2.0)':
     dependencies:
       '@json-render/core': 0.19.0
-      expr-eval: 2.0.2
       immer: 10.2.0
       zod: 4.4.3
 
@@ -5953,8 +5949,6 @@ snapshots:
       strip-final-newline: 3.0.0
 
   expect-type@1.4.0: {}
-
-  expr-eval@2.0.2: {}
 
   express@4.22.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ packages:
 catalogs:
   runtime:
     '@popperjs/core': ^2.11.8
-    '@tdesign/ai-chat-engine': ^0.0.2
+    '@tdesign/ai-chat-engine': ^0.0.3
     cherry-markdown: 0.11.8
     classnames: ^2.5.1
     clsx: ^2.1.1


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [x] 其他

### 🔗 相关 Issue

无。

### 💡 需求背景和解决方案

`@tdesign/ai-chat-engine` 已发布 `0.0.3`。本 PR 将 runtime catalog 从 `^0.0.2` 升级到 `^0.0.3`，并同步更新 pnpm lockfile，使 `@tdesign/pro-components-chat` 与 `@tdesign/web-components-chat` 统一解析到 `0.0.3`。

发布包公开类型对比未发现删除或重命名 API；新增参数均为可选参数。已验证运行时导入及 `ChatEngine` 初始化/销毁、类型检查、Chat 契约、单元测试和 Chat 生产构建。

验证结果：

- `pnpm install --frozen-lockfile`
- `pnpm run check:types`
- `pnpm test`（24/24）
- Chat runtime import/init/destroy smoke
- `pnpm run build:chat`
- `pnpm --filter @tdesign/web-components-chat pack`，发布清单解析为 `@tdesign/ai-chat-engine: ^0.0.3`

说明：`pnpm run check:pack` 的 Chat 构建阶段通过，随后被当前仓库已有的 UI/Chat peer dependency 一致性检查拦截；当前 Chat 清单将 `@tdesign/web-components` 声明在 `dependencies`，而检查脚本要求其位于 `peerDependencies`。该问题与本次依赖升级无关。

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

#### @tdesign/web-components

#### @tdesign/web-components-chat

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
